### PR TITLE
Drifter

### DIFF
--- a/src/tred/drift.py
+++ b/src/tred/drift.py
@@ -140,8 +140,11 @@ def drift(locs, velocity, diffusion, lifetime, target=0,
     - sigma :: real 1D (npts,) or 2D (npts,vdim) tensor giving initial sigma.  Default is none.
     - fluctuate :: bool apply random fluctuation to charge.  Default is False.
     - tshift :: real positive scalar (number or 0D tensor), to correct for drift time from response plane to anode.
+                Note: users must be responsible for the correct shift in use.
     - drtoa :: real positive scalar (number or 0D tensor). The distance along drift direction from response plane
                to anode plane, abs(loc_anode - loc_response). It is mutually exclusive with tshift. Default to None.
+               Note: users must be responsible for the consistency between drift velocity in TRED
+               and in field response calculations.
 
     FIXME: units of drtoa must be consistent with locs.
     '''

--- a/src/tred/drift.py
+++ b/src/tred/drift.py
@@ -34,7 +34,7 @@ def diffuse(dt, diffusion, sigma=None):
     Return new Gaussian diffusion sigma after drifting by time dt.
 
     - dt :: scalar or real 1D tensor of drift times (npts,).
-    - diffusion :: real scalar or 1D (vdim,) tensor of diffusion coefficients.
+    - diffusion :: real scalar (number or 0D tensor) or 1D (vdim,) tensor of diffusion coefficients.
     - sigma :: real 1D (npts) or 2D (npts,vdim) tensor or None.
 
     A sigma of None indicate no prior diffusion.
@@ -48,6 +48,11 @@ def diffuse(dt, diffusion, sigma=None):
     # eg, diffusion is 5; it cannot be a list/tuple
     if not isinstance(diffusion, torch.Tensor):
         diffusion = torch.tensor([diffusion], device=dt.device)
+        squeeze = True
+
+    # eg, diffusion is a 0D tensor
+    if diffusion.dim() == 0:
+        diffusion = diffusion.unsqueeze(0)
         squeeze = True
 
     if len(dt.shape) != 1:

--- a/src/tred/drift.py
+++ b/src/tred/drift.py
@@ -90,6 +90,8 @@ def absorb(charge, dt, lifetime, fluctuate=False):
 
     Note, negative dt will lead to exponential increase not decrease.  Ie,
     implies that the drift "backed up" the point.
+    This is unphysical. The surviving electrons (charge) remain the same when dt is negative.
+    No negative binomial fluctuations or any factor from the exponential distribution is applied.
     '''
     charge = charge.to(dtype=torch.int32)
     if fluctuate:
@@ -97,8 +99,7 @@ def absorb(charge, dt, lifetime, fluctuate=False):
         loss = torch.clamp(loss, 0, 1, out=loss)
         b = Binomial(charge, loss)
         return charge - b.sample()
-
-    return charge * torch.exp(-dt / lifetime)
+    return torch.where(dt>=0, charge * torch.exp(-dt / lifetime), charge)
 
 
 def drift(locs, velocity, diffusion, lifetime, target=0,

--- a/src/tred/drift.py
+++ b/src/tred/drift.py
@@ -45,7 +45,7 @@ def diffuse(dt, diffusion, sigma=None):
     '''
     squeeze = False
 
-    # eg, diffusion is 5, [5] or [4,5,6]
+    # eg, diffusion is 5; it cannot be a list/tuple
     if not isinstance(diffusion, torch.Tensor):
         diffusion = torch.tensor([diffusion], device=dt.device)
         squeeze = True
@@ -105,6 +105,11 @@ def drift(locs, velocity, diffusion, lifetime, target=0,
 
       (locs, times, sigma, charges)
 
+    - locs :: 1D (npts, ) or 2D (npts, vdim) tensor of the updated locs. The original locs is kept except along vaxis. locs along vaxis is updated to target.
+    - times :: tensor with the same shape as locs's. It is initial time (the argument times) + dt (from transport).
+    - sigma :: real 1D (npts,) or 2D (npts, vdim) tensors by adding the initial sigma and diffusion width in quadrature.
+    - charges :: quenched charges by function absorb.
+
     Required arguments:
 
     - locs :: 1D (npts,) or 2D (npts,vdim) tensor of initial locations.
@@ -148,7 +153,7 @@ def drift(locs, velocity, diffusion, lifetime, target=0,
     else:
         times = times + dt
 
-    debug(f'dt:{tenstr(dt)} diffusion:{tenstr(diffusion)}')
+    debug(f'dt:{tenstr(dt)} diffusion:{tenstr(diffusion) if isinstance(diffusion, torch.Tensor) else diffusion}')
     sigma = diffuse(dt, diffusion=diffusion, sigma=sigma)
 
     default_charge = 1000

--- a/src/tred/graph.py
+++ b/src/tred/graph.py
@@ -100,6 +100,12 @@ class Drifter(nn.Module):
         Drift depos or steps.
 
         Returns tuple one larger than input args with sigma prepended.
+
+        dsigma :: post-drift diffusion width at target plane.
+        dtime :: post-drift time is the time for tail. Shifts may be applied.
+        dcharge :: post-drift charge at target plane.
+        dtail :: post-drift positions of tail.
+        dhead :: post-drift positions of head.
         '''
 
         # note, can in principle, drift with pare-existing sigmas.  But here we

--- a/src/tred/graph.py
+++ b/src/tred/graph.py
@@ -60,8 +60,12 @@ class Drifter(nn.Module):
     def __init__(self, diffusion, lifetime, velocity,
                  target=0, vaxis=0, fluctuate=False):
         '''
+        diffusion :: diffusion coefficients, real scalar (number or 0D tensor), or 1D tensor, or plain list/tuple.
+                     The 1D tensor or plain list/tuple must be a sequence of numbers in a size of (vdim,)
         velocity is signed scalar
         vaxis is the axis on which the velocity is defined. default=0 (x)
+
+        All parameters will be set to a constant tensor in the class instance.
         '''
         super().__init__()
         if target is None:

--- a/tests/drift/benchmark_drift.py
+++ b/tests/drift/benchmark_drift.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+
+import torch
+import torch.utils.benchmark as benchmark
+import matplotlib.pyplot as plt
+import sys
+
+from tred.graph import Drifter
+
+import numpy as np
+
+#############################################
+# Benchmark script using torch.utils.benchmark
+# and basic memory usage checks.
+#############################################
+
+def run_benchmark(
+    npt: int,
+    device: str,
+    repeats: int = 100,
+):
+    """
+    Construct random input and measure execution time and approximate
+    peak memory usage on the given device.
+    """
+
+    # Prepare random input data
+    # shapes: time, charge: (npt,)
+    # tail, head: (npt, 3)
+    time_data = torch.zeros(npt, dtype=torch.float32)  # some or random times
+    charge_data = torch.randint(800, 1200, (npt,), dtype=torch.int32).to(torch.float32)
+    tail_data = torch.randn(npt, 3, dtype=torch.float32)
+    head_data = torch.randn(npt, 3, dtype=torch.float32)
+
+    # Send to device
+    time_data = time_data.to(device)
+    charge_data = charge_data.to(device)
+    tail_data = tail_data.to(device)
+    head_data = head_data.to(device)
+
+    # Create Drifter object
+    drifter = Drifter(
+        diffusion=[5.0, 5.0, 5.0],
+        lifetime=2.0,
+        velocity=1.0,
+        target=0.0,
+        vaxis=0,
+        fluctuate=False,
+        drtoa=1.
+    ).to(device)
+
+    # We create a simple callable for the benchmark
+    def drifter_forward():
+        with torch.no_grad():
+            drifter(time_data, charge_data, tail_data, head_data)
+
+    # --- Time measurement ---
+    t = benchmark.Timer(
+        stmt='drifter_forward()',
+        globals={'drifter_forward': drifter_forward},
+    )#.timeit(repeats)
+    m = t.blocked_autorange()
+
+    # We'll capture the average time per run
+    avg_time_ms = m.mean * 1E3 #ms
+
+    # --- Memory measurement ---
+    #
+    # For GPU:
+    #   Reset peak stats, run once more, then measure.
+    # For CPU:
+    #   We approximate memory usage by summing the sizes of the input and output.
+    #   A more sophisticated approach may be used if needed.
+    peak_mem_bytes = 0
+    input_mem_bytes = 0
+    if device.startswith('cuda'):
+        torch.cuda.reset_peak_memory_stats()
+        with torch.no_grad():
+            drifter(time_data, charge_data, tail_data, head_data)
+        peak_mem_bytes = torch.cuda.max_memory_allocated()
+        # Input memory
+        input_mem_bytes += time_data.element_size() * time_data.nelement()
+        input_mem_bytes += charge_data.element_size() * charge_data.nelement()
+        input_mem_bytes += tail_data.element_size() * tail_data.nelement()
+        input_mem_bytes += head_data.element_size() * head_data.nelement()
+    else:
+        # CPU "peak" is trickier to measure precisely without external libraries.
+        # We'll do a naive sum of input sizes as "peak" for demonstration.
+        # If you want real usage, consider memory_profiler or psutil.
+        with torch.no_grad():
+            drifter(time_data, charge_data, tail_data, head_data)
+
+        # Just approximate everything for demonstration:
+        time_mem = time_data.element_size() * time_data.nelement()
+        charge_mem = charge_data.element_size() * charge_data.nelement()
+        tail_mem = tail_data.element_size() * tail_data.nelement()
+        head_mem = head_data.element_size() * head_data.nelement()
+
+        # We'll say the model also has some overhead:
+        model_mem = sum(p.element_size() * p.nelement() for p in drifter.parameters())
+
+        peak_mem_bytes = time_mem + charge_mem + tail_mem + head_mem + model_mem
+        input_mem_bytes = time_mem + charge_mem + tail_mem + head_mem
+
+    # We measure the ratio of peak memory usage to the size of just the input tensors:
+    mem_ratio = float(peak_mem_bytes) / float(input_mem_bytes) if input_mem_bytes else 0.0
+
+    return avg_time_ms, mem_ratio, peak_mem_bytes, input_mem_bytes
+
+
+def main():
+    # Vary npt (number of points)
+    npt_list = [1000, 5000, 10000, 50000, 100000, 1_000_000, 5_000_000, 10_000_000]
+
+    cpu_results_time = []
+    cpu_results_memratio = []
+    gpu_results_time = []
+    gpu_results_memratio = []
+    gpu_results_peak_mem = []
+    gpu_results_mem = []
+
+    # Run on CPU
+    for npt in npt_list:
+        t, _, _, _ = run_benchmark(npt, 'cpu', repeats=50)
+        cpu_results_time.append(t)
+        print(f"CPU npt={npt}: time={t:.3f} ms")
+
+    # Check if CUDA is available, then run on GPU
+    if torch.cuda.is_available():
+        for npt in npt_list:
+            t, r, pm, m = run_benchmark(npt, 'cuda', repeats=50)
+            gpu_results_time.append(t)
+            gpu_results_memratio.append(r)
+            gpu_results_peak_mem.append(pm)
+            gpu_results_mem.append(m)
+            print(f"GPU npt={npt}: time={t:.3f} ms")
+    else:
+        print("CUDA is not available. GPU benchmarks skipped.")
+
+    # --- Plot the results ---
+    # 1) Time vs. npt
+    plt.figure()
+    plt.plot(npt_list, cpu_results_time, 'o-', label='CPU')
+    if gpu_results_time:
+        plt.plot(npt_list, gpu_results_time, 'ro-', label='GPU')
+    for x, y in zip(npt_list, gpu_results_time):
+        plt.text(x, y, f'{y:.2f} ms', fontsize=10, ha='right', va='bottom', color='r')
+    plt.xlabel('Input length (npt)')
+    plt.xscale('log')
+    plt.ylabel('Average execution time (ms)')
+    plt.title('Drifter Benchmark: Execution Time vs Input Length')
+    plt.legend()
+    plt.show()
+    plt.savefig('benchmark_running_time.png')
+
+    plt.figure()
+    plt.plot(gpu_results_mem, cpu_results_time, 'o-', label='CPU')
+    if gpu_results_time:
+        plt.plot(gpu_results_mem, gpu_results_time, 'ro-', label='GPU')
+    for x, y in zip(gpu_results_mem, gpu_results_time):
+        plt.text(x, y, f'{y:.2f} ms', fontsize=10, ha='right', va='bottom', color='r')
+    # Annotate each GPU point with its value
+    plt.xlabel('Mem for input data [MB]')
+    plt.xscale('log')
+    plt.ylabel('Average execution time (ms)')
+    plt.title('Drifter Benchmark: Execution Time vs Input Length')
+    plt.legend()
+    plt.show()
+    plt.savefig('benchmark_running_time_mem.png')
+
+    # 2) Memory ratio vs. npt
+    plt.figure()
+    if gpu_results_time:
+        plt.plot(npt_list, gpu_results_memratio, 'o-', label='GPU')
+    plt.xlabel('Input length (npt)')
+    plt.ylabel('Peak Mem / Input Mem')
+    plt.title('Drifter Benchmark: Memory Ratio vs Input Length')
+    plt.legend()
+    plt.show()
+
+    plt.savefig('benchmark_mem_ratio.png')
+
+    # 3) Memory vs. npt
+    plt.figure()
+    if gpu_results_time:
+        plt.plot(npt_list, np.array(gpu_results_mem)/1024**2, 'o-', label='GPU')
+    plt.xlabel('Input length (npt)')
+    plt.xscale('log')
+    plt.ylabel('Peak Mem (MB)')
+    plt.title('Drifter Benchmark: Peak memory vs Input Length')
+    plt.legend()
+    plt.show()
+
+    plt.savefig('benchmark_peak_mem.png')
+
+if __name__ == "__main__":
+    main()

--- a/tests/drift/test_absorb.py
+++ b/tests/drift/test_absorb.py
@@ -1,0 +1,196 @@
+import torch
+import pytest
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Make sure the 'absorb' function and Binomial class are defined/imported in the test context.
+# For example, if using torch.distributions.Binomial, you may import it in the same module as absorb.
+
+from tred.drift import absorb
+
+def test_absorb_return_type():
+    dt = torch.tensor([1.0, 2.0])
+    charge = torch.tensor([100, 200])
+    lifetime = 1.0
+    # Expected survival: charge * exp(-dt / lifetime)
+    result0 = absorb(charge, dt, lifetime, fluctuate=False)
+    result1 = absorb(charge, dt, lifetime, fluctuate=True)
+    assert result0.dtype == torch.float32 and result1.dtype == torch.float32, \
+            f'dtype when fluctuate==False is {result0.dtype}, '\
+            f'dtype when fluctuate==True is {result1.dtype}'
+
+def test_absorb_deterministic():
+    # Test the deterministic mode (fluctuate=False)
+    dt = torch.tensor([1.0, 2.0])
+    charge = torch.tensor([100, 200])
+    lifetime = 1.0
+    # Expected survival: charge * exp(-dt / lifetime)
+    expected = charge * torch.exp(- dt / lifetime)
+    result = absorb(charge, dt, lifetime, fluctuate=False)
+    assert torch.allclose(result, expected), f"Expected {expected}, got {result}"
+
+def test_absorb_dt_zero():
+    # When dt is zero, no absorption should occur (both modes should return the original charge)
+    dt = torch.tensor([0.0])
+    charge = torch.tensor([50.])
+    lifetime = 1.0
+    expected = charge  # exp(0)=1 so no change
+    result_det = absorb(charge, dt, lifetime, fluctuate=False)
+    result_fluc = absorb(charge, dt, lifetime, fluctuate=True)
+    print(expected.dtype)
+    assert torch.allclose(result_det, expected), f"Deterministic: Expected {expected}, got {result_det}"
+    assert torch.allclose(result_fluc, expected), f"Fluctuating: Expected {expected}, got {result_fluc}"
+
+def test_absorb_negative_dt():
+    # Negative dt should result in an increase: exp(-(-dt)/lifetime) = exp(dt/lifetime) > 1.
+    dt = torch.tensor([-1.0, -2.0])
+    charge = torch.tensor([100, 200])
+    lifetime = 1.0
+    expected = charge * torch.exp(- dt / lifetime)  # note: - dt is positive here
+    result = absorb(charge, dt, lifetime, fluctuate=False)
+    assert torch.allclose(result, expected), f"Expected {expected}, got {result}"
+
+def test_absorb_fluctuate_range():
+    # In fluctuate mode, the surviving charge should be between 0 and the original charge.
+    dt = torch.tensor([1.0, 2.0])
+    charge = torch.tensor([100, 200])
+    lifetime = 1.0
+    result = absorb(charge, dt, lifetime, fluctuate=True)
+    # Verify each element is at least 0 and does not exceed the initial charge.
+    assert torch.all(result >= 0), f"Some values are below 0: {result}"
+    assert torch.all(result <= charge), f"Some values exceed the initial charge: {result}"
+
+def test_absorb_fluctuate_mean():
+    # Test that the average over many samples is close to the deterministic expectation.
+    dt = torch.tensor([1.0, 2.0])
+    charge = torch.tensor([100, 200])
+    lifetime = 1.0
+    expected = charge * torch.exp(- dt / lifetime)
+
+    num_samples = 10000
+    samples = []
+    for _ in range(num_samples):
+        samples.append(absorb(charge, dt, lifetime, fluctuate=True))
+    samples = torch.stack(samples)  # shape: (num_samples, npts)
+    sample_mean = torch.mean(samples.float(), dim=0)
+
+    # Allow some tolerance given the stochastic fluctuations.
+    assert torch.allclose(sample_mean, expected.float(), rtol=0.1, atol=1.0), (
+        f"Expected mean approx. {expected}, got {sample_mean}"
+    )
+
+
+# ================== Plotting Function ==================
+def plot_charge_distributions():
+    # Create a figure with two subplots (axes)
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 12))
+
+    # ------------------ First Plot: Charge Distributions ------------------
+    num_samples = 10000
+    initial_charge = torch.tensor([100])
+    dt_values = [-0.5, 0, 0.5, 1.0, 2.0, 3.0]
+    lifetime = 1.0
+
+    cmap = plt.get_cmap('viridis', len(dt_values))
+
+    for i, dt in enumerate(dt_values):
+        dt_tensor = torch.tensor([dt])
+        # Vectorized simulation: repeat initial charge and dt for num_samples trials
+        result = absorb(initial_charge.repeat(num_samples), dt_tensor.repeat(num_samples),
+                        lifetime, fluctuate=True)
+        samples = result.tolist()
+
+        color = cmap(i)
+        ax1.hist(samples, bins=110, range=(-0.5, 109.5), alpha=0.5,
+                 label=f'dt = {dt}', color=color)
+
+        # Deterministic expected surviving charge (fluctuate=False)
+        expected = absorb(initial_charge, dt_tensor, lifetime, fluctuate=False).item()
+        # Mean of the stochastic samples
+        mean_sample = np.mean(samples)
+
+        # Compute loss fraction and theoretical variance for dt > 0, else loss=1.
+        if dt > 0:
+            loss = 1 - (expected / initial_charge.item())
+        else:
+            loss = 1.0
+        theoretical_variance = initial_charge.item() * loss * (1 - loss)
+        measured_variance = np.var(samples, ddof=1)
+
+        # Add text annotation with variances
+        ax1.text(0.05, 0.95 - i*0.05,
+                 f"dt:{dt:.1f}, var (theory): {theoretical_variance:02.2f}, var (measured): {measured_variance:02.2f}",
+                 transform=ax1.transAxes, fontsize=12, color='black')
+
+        # Vertical lines for deterministic expectation and sample mean
+        ax1.axvline(x=expected, color=color, linestyle='--', linewidth=2,
+                    label=f'Expected (dt={dt})')
+        ax1.axvline(x=mean_sample, color=color, linestyle='-', linewidth=2,
+                    label=f'Mean (dt={dt})')
+    ax1.text(0.15, 0.5, f'initial charge {initial_charge.item()}; lifetime {lifetime}',
+             transform=ax1.transAxes, fontsize=12, color='black')
+
+    ax1.set_xlabel('Surviving Charge')
+    ax1.set_ylabel('Frequency')
+    ax1.set_title('Charge Distributions for Different dt Values')
+    ax1.legend()
+
+    # ------------------ Second Plot: Surviving Charge vs. dt ------------------
+    # Parameters for second plot (using a different initial charge)
+    lifetime = 1.0
+    initial_charge2 = torch.full((100,), 100)
+    dt_values_line = torch.linspace(0, 5, len(initial_charge2))
+    dt_curve = torch.linspace(0, 5, 1000)
+
+    deterministic_points = absorb(initial_charge2, dt_values_line, lifetime, fluctuate=False)
+    stochastic_points = absorb(initial_charge2, dt_values_line, lifetime, fluctuate=True)
+    theory_curve = torch.full((len(dt_curve),), initial_charge2[0].item()) * torch.exp(-dt_curve/lifetime)
+
+    neg_dt_values = torch.linspace(-0.5, 0, 5)
+    neg_dt_curve = torch.linspace(-0.5, 0, 200)
+    neg_det_points = absorb(torch.full((len(neg_dt_values),), initial_charge2[0].item()),
+                             neg_dt_values, lifetime, fluctuate=False)
+    neg_sto_points = absorb(torch.full((len(neg_dt_values),), initial_charge2[0].item()),
+                             neg_dt_values, lifetime, fluctuate=True)
+    neg_the_curve = torch.full((len(neg_dt_curve),), initial_charge2[0].item()) * torch.exp(-neg_dt_curve/lifetime)
+
+    # Compute error (vertical range) for the theory curve
+    error_curve = torch.full((len(dt_curve),), initial_charge2[0].item()) * \
+                  torch.exp(-dt_curve/lifetime) * (1 - torch.exp(-dt_curve/lifetime))
+
+    # Plot negative dt part of theory curve
+    ax2.plot(neg_dt_curve.numpy(), neg_the_curve.numpy(), 'k-', linewidth=2)
+    # Plot positive dt theory curve and shaded uncertainty
+    ax2.plot(dt_curve.numpy(), theory_curve.numpy(), 'k-', linewidth=2, label='Theory: N₀ exp(-dt/lifetime)')
+    ax2.fill_between(dt_curve.numpy(),
+                     (theory_curve - error_curve).numpy(),
+                     (theory_curve + error_curve).numpy(),
+                     color='gray', alpha=0.3, label='Theory ± expected binomial variance')
+    # Plot deterministic and stochastic points
+    ax2.plot(dt_values_line.numpy(), deterministic_points.numpy(), 'bo', label='Fluctuate=False')
+    ax2.plot(neg_dt_values.numpy(), neg_det_points.numpy(), 'bo')
+    ax2.plot(dt_values_line.numpy(), stochastic_points.numpy(), 'ro', label='Fluctuate=True')
+    ax2.plot(neg_dt_values.numpy(), neg_sto_points.numpy(), 'ro')
+
+    ax2.text(0.65, 0.5, f'initial charge {initial_charge2[0].item()}; lifetime {lifetime}',
+             transform=ax2.transAxes, fontsize=12, color='black')
+
+    ax2.set_xlabel('dt')
+    ax2.set_ylabel('Surviving Charge')
+    ax2.set_title('Surviving Charge vs. dt')
+    ax2.legend()
+
+    fig.tight_layout()
+    plt.show()
+    fig.savefig('absorb.png')
+
+
+# ================== Example Execution ==================
+
+if __name__ == "__main__":
+    # Run tests
+    pytest.main([__file__])
+
+    # Plot distributions for given dt values.
+    plot_charge_distributions()

--- a/tests/drift/test_absorb.py
+++ b/tests/drift/test_absorb.py
@@ -48,6 +48,7 @@ def test_absorb_negative_dt():
     charge = torch.tensor([100, 200])
     lifetime = 1.0
     expected = charge * torch.exp(- dt / lifetime)  # note: - dt is positive here
+    expected[dt<0] = charge[dt<0].to(torch.float32)
     result = absorb(charge, dt, lifetime, fluctuate=False)
     assert torch.allclose(result, expected), f"Expected {expected}, got {result}"
 
@@ -163,16 +164,16 @@ def plot_charge_distributions():
     # Plot negative dt part of theory curve
     ax2.plot(neg_dt_curve.numpy(), neg_the_curve.numpy(), 'k-', linewidth=2)
     # Plot positive dt theory curve and shaded uncertainty
-    ax2.plot(dt_curve.numpy(), theory_curve.numpy(), 'k-', linewidth=2, label='Theory: N₀ exp(-dt/lifetime)')
+    ax2.plot(dt_curve.numpy(), theory_curve.numpy(), 'k-', linewidth=2, label='ExpoDist: N₀ exp(-dt/lifetime)')
     ax2.fill_between(dt_curve.numpy(),
                      (theory_curve - error_curve).numpy(),
                      (theory_curve + error_curve).numpy(),
-                     color='gray', alpha=0.3, label='Theory ± expected binomial variance')
+                     color='gray', alpha=0.3, label='ExpoDist ± expected binomial variance')
     # Plot deterministic and stochastic points
     ax2.plot(dt_values_line.numpy(), deterministic_points.numpy(), 'bo', label='Fluctuate=False')
     ax2.plot(neg_dt_values.numpy(), neg_det_points.numpy(), 'bo')
-    ax2.plot(dt_values_line.numpy(), stochastic_points.numpy(), 'ro', label='Fluctuate=True')
-    ax2.plot(neg_dt_values.numpy(), neg_sto_points.numpy(), 'ro')
+    ax2.plot(dt_values_line.numpy(), stochastic_points.numpy(), 'r*', label='Fluctuate=True')
+    ax2.plot(neg_dt_values.numpy(), neg_sto_points.numpy(), 'r*')
 
     ax2.text(0.65, 0.5, f'initial charge {initial_charge2[0].item()}; lifetime {lifetime}',
              transform=ax2.transAxes, fontsize=12, color='black')

--- a/tests/drift/test_absorb.py
+++ b/tests/drift/test_absorb.py
@@ -158,6 +158,7 @@ def plot_charge_distributions():
     # Compute error (vertical range) for the theory curve
     error_curve = torch.full((len(dt_curve),), initial_charge2[0].item()) * \
                   torch.exp(-dt_curve/lifetime) * (1 - torch.exp(-dt_curve/lifetime))
+    error_curve = np.sqrt(error_curve)
 
     # Plot negative dt part of theory curve
     ax2.plot(neg_dt_curve.numpy(), neg_the_curve.numpy(), 'k-', linewidth=2)

--- a/tests/drift/test_diffuse.py
+++ b/tests/drift/test_diffuse.py
@@ -1,0 +1,72 @@
+import torch
+import pytest
+
+from tred.drift import diffuse
+
+# Assume the diffuse function is already defined
+
+def test_diffuse_scalar_diffusion_no_sigma():
+    # diffusion provided as a scalar (not a tensor)
+    dt = torch.tensor([1.0, 2.0, 3.0])
+    diffusion = 5.0
+    # Expected: sigma = sqrt(2 * diffusion * dt)
+    expected = torch.sqrt(2 * 5.0 * dt)
+    result = diffuse(dt, diffusion)
+    # Because diffusion was scalar, the function sets squeeze=True so that
+    # the extra dimension is removed.
+    assert torch.allclose(result, expected)
+
+def test_diffuse_vector_diffusion_no_sigma():
+    # diffusion provided as a 1D tensor (vector)
+    dt = torch.tensor([1.0, 2.0])
+    diffusion = torch.tensor([4.0, 5.0, 6.0])
+    # Expected: sigma = sqrt(2 * dt[:, None] * diffusion[None, :])
+    expected = torch.sqrt(2 * dt[:, None] * diffusion[None, :])
+    result = diffuse(dt, diffusion)
+    # In this case diffusion is already a tensor, so squeeze remains False and
+    # the output shape is (npts, diffusion_length)
+    assert torch.allclose(result, expected)
+
+def test_diffuse_with_sigma():
+    # Test the case where an initial sigma is provided.
+    dt = torch.tensor([1.0, 2.0])
+    diffusion = 1.0  # scalar diffusion
+    sigma_initial = torch.tensor([0.5, 1.0])  # one sigma per time point (1D)
+    # Expected: sigma = sqrt(2*diffusion*dt + sigma_initial^2)
+    expected = torch.sqrt(2 * 1.0 * dt + sigma_initial**2)
+    result = diffuse(dt, diffusion, sigma_initial)
+    # For scalar diffusion, squeeze=True so that the result is squeezed to shape (npts,)
+    assert result.shape == sigma_initial.shape
+    assert torch.allclose(result, expected)
+
+def test_diffuse_negative_dt():
+    # Test with a negative dt causing the argument of sqrt to be negative.
+    dt = torch.tensor([-1.0])
+    diffusion = 1.0
+    result = diffuse(dt, diffusion)
+    # sqrt(2*1*(-1)) = sqrt(-2) returns nan, which the function then sets to 0.
+    expected = torch.tensor(0.0)
+    assert torch.allclose(result, expected)
+
+def test_dt_shape_exception():
+    # dt must be 1D. Here we pass a 2D tensor.
+    dt = torch.tensor([[1.0, 2.0]])
+    diffusion = 1.0
+    with pytest.raises(ValueError):
+        diffuse(dt, diffusion)
+
+def test_diffusion_shape_exception():
+    # diffusion must be 1D. Here we pass a 2D tensor.
+    dt = torch.tensor([1.0])
+    diffusion = torch.tensor([[1.0]])
+    with pytest.raises(ValueError):
+        diffuse(dt, diffusion)
+
+def test_sigma_shape_exception():
+    # sigma's shape should span the same number of dimensions as diffusion (which is 1 for 1D diffusion)
+    # Here we provide a sigma with an extra dimension (2D instead of 1D)
+    dt = torch.tensor([1.0, 2.0])
+    diffusion = 1.0  # so diffusion is internally converted to a 1D tensor of length 1
+    sigma_wrong = torch.tensor([[0.5, 1.0]])  # shape (1, 2) does not match the expected 1D shape for sigma
+    with pytest.raises(ValueError):
+        diffuse(dt, diffusion, sigma_wrong)

--- a/tests/drift/test_drift.py
+++ b/tests/drift/test_drift.py
@@ -88,12 +88,12 @@ def test_drift_sigma_consistency():
 
 def test_drift_charge_quenching():
     """Ensure charges decrease over time for dt > 0 and are of float type."""
-    locs = torch.tensor([1.0, 3.0])
+    locs = torch.tensor([1.0, 3.0, 7.0])
     velocity = 2.0
     diffusion = 0.1
     lifetime = 10.0
     target = 5.0
-    charge = torch.tensor([100, 200])
+    charge = torch.tensor([100, 200, 200])
 
     _, _, _, charge_out = drift(locs, velocity, diffusion, lifetime, target=target, charge=charge)
     assert torch.all(charge_out <= charge), "Charge should not increase"

--- a/tests/drift/test_drift.py
+++ b/tests/drift/test_drift.py
@@ -1,0 +1,124 @@
+import torch
+import pytest
+from tred.drift import drift
+
+def test_drift_input_validation():
+    """Ensure drift function properly handles incorrect input types and shapes."""
+    locs = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    velocity = 1.0
+    diffusion = torch.tensor([0.1, 0.2])
+    lifetime = 10.0
+
+    with pytest.raises(ValueError):
+        drift(locs, velocity, torch.tensor([[0.1]]), lifetime)  # Incorrect diffusion shape
+
+    with pytest.raises(ValueError):
+        drift(locs, velocity, diffusion, lifetime, vaxis=3)  # Out of bounds vaxis
+
+    with pytest.raises(ValueError):
+        drift(locs, velocity, diffusion, lifetime, sigma=torch.tensor([[0.1]]))  # Mismatched sigma shape
+
+def test_drift_locs_update():
+    """Check if locs are updated correctly along vaxis."""
+    locs = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    velocity = 1.0
+    diffusion = torch.tensor([0.1, 0.2])
+    lifetime = 10.0
+    vaxis = 1
+    target = 5.0
+
+    locs_out, _, _, _ = drift(locs, velocity, diffusion, lifetime, target=target, vaxis=vaxis)
+    assert torch.allclose(locs_out[:, vaxis], torch.full((len(locs),), target)), "locs[vaxis] should be set to target"
+    assert torch.allclose(locs_out[:, 0], locs[:, 0]), "Other loc dimensions should remain unchanged"
+
+def test_drift_times_update():
+    """Check if times are updated correctly."""
+    locs = torch.tensor([1.0, 3.0])
+    velocity = 2.0
+    diffusion = 0.1
+    lifetime = 10.0
+    target = 5.0
+    times = torch.tensor([0.5, 1.0])
+
+    dt = (target - locs) / velocity
+    _, times_out, _, _ = drift(locs, velocity, diffusion, lifetime, target=target, times=times)
+    assert torch.allclose(times_out, times + dt), "Times should be incremented by dt"
+
+def test_neg_drift_velocity():
+    '''Check if sigmas are 0, dt < 0 when velocity is negative and target - loc > 0'''
+    locs = torch.tensor([1.0, 3.0])
+    velocity = -2.0
+    diffusion = 0.1
+    lifetime = 10.0 # dummy values
+    target = 5.0
+    _, times_out, sigma_out, _ = drift(locs, velocity, diffusion, lifetime, target=target)
+    assert torch.all(times_out<0), f'Output times, i.e., dt, {times_out} should be negative.'
+    assert torch.allclose(sigma_out, torch.tensor(0.), atol=1E-6), f'Output sigma, {sigma_out}, should be 0 when dt is negative.'
+
+def test_default_charge_dtype():
+    """Check whether default charge's dtype and its value equal to 1000"""
+    locs = torch.tensor([3.0, 3.0])
+    velocity = 2.0
+    diffusion = 0.1
+    lifetime = 10.0 # dummy values
+    target = 3.0
+    _, _, _, charges_out = drift(locs, velocity, diffusion, lifetime, target=target)
+    assert charges_out.dtype == torch.float32, f'Expected charges.dtype is float32 while the output is {charges_out.dtype}.'
+    assert charges_out.allclose(torch.full((locs.size(0),), 1000.), rtol=1E-6)
+
+def test_drift_sigma_consistency():
+    """Ensure sigma follows expected diffusion scaling."""
+    locs = torch.tensor([1.0, 3.0])
+    velocity = 2.0
+    diffusion = 0.1
+    lifetime = 10.0
+    target = 5.0
+    dt = (target - locs) / velocity
+
+    _, _, sigma_out, _ = drift(locs, velocity, diffusion, lifetime, target=target)
+    expected_sigma = torch.sqrt(2 * diffusion * dt)
+    assert torch.allclose(sigma_out, expected_sigma), "Sigma should follow sqrt(2 * diffusion * dt)"
+
+def test_drift_charge_quenching():
+    """Ensure charges decrease over time for dt > 0 and are of float type."""
+    locs = torch.tensor([1.0, 3.0])
+    velocity = 2.0
+    diffusion = 0.1
+    lifetime = 10.0
+    target = 5.0
+    charge = torch.tensor([100, 200])
+
+    _, _, _, charge_out = drift(locs, velocity, diffusion, lifetime, target=target, charge=charge)
+    assert torch.all(charge_out <= charge), "Charge should not increase"
+    assert charge_out.dtype == torch.float32, "Charge should be in float format"
+
+def test_drift_single_dimension():
+    """Check if times are updated correctly."""
+    locs = torch.tensor([1.0, 3.0])
+    velocity = 2.0
+    diffusion = 0.1
+    lifetime = 10.0
+    target = 5.0
+    times = torch.tensor([0.5, 1.0])
+
+    locs, _, _, _ = drift(locs, velocity, diffusion, lifetime, target=target, times=times)
+    assert len(locs.shape) == 1, f'Shape of locs should be preserved after squeezing.'
+    assert locs.allclose(torch.full((len(locs),), target)), f'locs should be updated to target'
+
+def test_drift_multiple_dimensions():
+    """Ensure function handles multi-dimensional locs correctly."""
+    locs = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    velocity = 1.0
+    diffusion = torch.tensor([0.1, 0.2])
+    lifetime = 10.0
+    vaxis = 1
+    target = 5.0
+
+    locs_out, times_out, sigma_out, charge_out = drift(locs, velocity, diffusion, lifetime, target=target, vaxis=vaxis)
+    assert locs_out.shape == locs.shape, "Shape of locs should be preserved"
+    assert times_out.shape == (2,), "Times should match the number of points"
+    assert sigma_out.shape == (2, 2), "Sigma should have correct shape, expected npt, vdim = {locs.shape}"
+    assert charge_out.shape == (2,), "Charge should match the number of points"
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/drift/test_drifter.py
+++ b/tests/drift/test_drifter.py
@@ -2,6 +2,8 @@ import pytest
 import torch
 from tred.graph import Drifter
 
+import matplotlib.pyplot as plt
+
 @pytest.mark.parametrize("diffusion,lifetime,velocity,target,expect_error", [
     (None, 10.0, 1.0, 0.0, True),      # diffusion is None
     (0.1, None, 1.0, 0.0, True),       # lifetime is None
@@ -173,3 +175,202 @@ def test_drifter_vaxis_out_of_range():
     with pytest.raises(ValueError, match="illegal vector axis"):
         drifter = Drifter(diffusion=0.1, lifetime=10.0, velocity=1.0, target=0.0, vaxis=10)
         drifter(None, None, torch.tensor([1., 2.]))
+
+def plot_drifter_simulations():
+    """
+    Combined plot with:
+      - Upper panel: Output Time vs. Initial Location (drift simulation).
+      - Lower panel: Resulting Charge vs. Initial Location (drift absorption).
+    """
+    # -----------------------
+    # Upper Panel: Drift Times vs. Locations
+    # -----------------------
+    # Simulation parameters for drift times
+    velocity = 2.0         # units: distance/time
+    diffusion = 0.1        # units: (length^2)/time (not directly plotted)
+    lifetime = 10.0        # units: time (affects absorption, not plotted)
+    target = 5.0           # drift target location along the drift axis
+    constant_time = 1.0    # constant initial time for all inputs
+    vaxis = 0              # drift is along the first dimension
+    fluctuate = False      # use deterministic mode for clarity
+
+    # Create a Drifter instance with the given parameters.
+    drifter = Drifter(diffusion=diffusion, lifetime=lifetime, velocity=velocity,
+                      target=target, vaxis=vaxis, fluctuate=fluctuate)
+
+    # Generate a range of initial locations (for example, from 0 to 10)
+    initial_locs = torch.linspace(0, 10, 100)
+    # Create a constant initial time tensor.
+    initial_time = torch.full_like(initial_locs, constant_time)
+    # Set a constant charge (e.g., 1000 electrons) for each point.
+    initial_charge = torch.full_like(initial_locs, 1000, dtype=torch.float32)
+
+    # Preserve the initial locations (input independent variable)
+    input_locs = initial_locs.clone()
+
+    # Call Drifter.forward.
+    # Drifter.forward returns (dsigma, dtime, dcharge, dtail)
+    dsigma, dtime, dcharge, dtail = drifter.forward(initial_time, initial_charge, initial_locs)
+
+    # Convert tensors to numpy arrays for plotting.
+    input_locs_np = input_locs.numpy()
+    dtime_np = dtime.numpy()
+
+    # -----------------------
+    # Lower Panel: Charge vs. Locations
+    # -----------------------
+    # Simulation parameters for charge absorption
+    velocity_chg = 2.0     # units: distance/time
+    diffusion_chg = 0.1    # required by Drifter, though not used for theory curve
+    lifetime_chg = 2.0     # absorption lifetime (time units)
+    target_chg = 5.0       # drift target location along the drift axis
+    Q0 = 1000.0            # initial charge (electrons)
+    constant_time_chg = 0.0  # constant initial time for all inputs
+    vaxis_chg = 0          # drift along the first dimension
+
+    # Create two Drifter instances: one deterministic and one stochastic.
+    drifter_det = Drifter(diffusion=diffusion_chg, lifetime=lifetime_chg, velocity=velocity_chg,
+                          target=target_chg, vaxis=vaxis_chg, fluctuate=False)
+    drifter_sto = Drifter(diffusion=diffusion_chg, lifetime=lifetime_chg, velocity=velocity_chg,
+                          target=target_chg, vaxis=vaxis_chg, fluctuate=True)
+
+    # Generate a range of initial locations.
+    initial_locs_chg = torch.linspace(0, 10, 100)
+    # Create a constant initial time for all inputs.
+    initial_time_chg = torch.full_like(initial_locs_chg, constant_time_chg)
+    # Create a tensor for the initial charge.
+    initial_charge_chg = torch.full_like(initial_locs_chg, Q0, dtype=torch.float32)
+
+    # Compute the theoretical drift time for each location.
+    dt = (target_chg - initial_locs_chg) / velocity_chg
+    # Compute the theoretical surviving charge: Q_theory = Q0 * exp(- dt / lifetime)
+    Q_theory = Q0 * torch.exp(- dt / lifetime_chg)
+    # For dt > 0, compute the loss fraction and standard deviation.
+    L = 1 - torch.exp(- dt / lifetime_chg)
+    variance = Q0 * L * (1 - L)
+    std_dev = torch.sqrt(variance)
+    positive_mask = dt > 0
+
+    # Run the drift simulation using Drifter.forward.
+    # forward returns (dsigma, dtime, dcharge, dtail)
+    dsigma_det, dt_det, charge_det, _ = drifter_det.forward(initial_time_chg, initial_charge_chg, initial_locs_chg)
+    dsigma_sto, dt_sto, charge_sto, _ = drifter_sto.forward(initial_time_chg, initial_charge_chg, initial_locs_chg)
+
+    # Convert tensors to numpy for plotting.
+    locs_np = initial_locs_chg.numpy()
+    Q_theory_np = Q_theory.numpy()
+    charge_det_np = charge_det.numpy()
+    charge_sto_np = charge_sto.numpy()
+    std_np = std_dev.numpy()
+
+    dt_det_np = dt_det.numpy()
+    dt_sto_np = dt_sto.numpy()
+    dsigma_det_p1 = dsigma_det.numpy() + 1
+    dsigma_sto_p1 = dsigma_sto.numpy() + 1
+
+    # -----------------------
+    # Create a figure with 3 rows, 2 columns
+    #   Row 1: ax1 spans columns 1-2
+    #   Row 2: ax2 spans columns 1-2
+    #   Row 3: ax3 (col 1), ax4 (col 2)
+    # -----------------------
+    fig = plt.figure(figsize=(10, 14))
+
+    # Top row (row=1), spanning columns 1 and 2
+    ax1 = fig.add_subplot(3, 2, (1, 2))
+    # Second row (row=2), spanning columns 1 and 2
+    ax2 = fig.add_subplot(3, 2, (3, 4))
+    # Third row, left column (row=3, col=1)
+    ax3 = fig.add_subplot(3, 2, 5)
+    # Third row, right column (row=3, col=2)
+    ax4 = fig.add_subplot(3, 2, 6)
+
+    # # -----------------------
+    # # Create Combined Figure with Two Subplots
+    # # -----------------------
+    # fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(10, 6*3))
+
+    # Upper panel: Drift times vs. Initial Location
+    ax1.plot(input_locs_np, dtime_np, 'bo-', label='Output Time')
+    ax1.set_xlabel('Initial Location')
+    ax1.set_ylabel('Output Time')
+    ax1.set_title('Output Time vs. Initial Location (Drift Simulation)')
+    # Mark the target location with a vertical dashed line.
+    ax1.axvline(x=target, color='r', linestyle='--', label=f'Target = {target}')
+    # Mark the constant initial time with a horizontal dashed line.
+    ax1.axhline(y=constant_time, color='g', linestyle='--', label=f'Initial Time = {constant_time}')
+    # Add text annotations for velocity and target information.
+    ax1.text(0.05, 0.95, f'Velocity: {velocity}', transform=ax1.transAxes,
+             fontsize=12, verticalalignment='top')
+    ax1.text(0.05, 0.90, f'Target: {target}', transform=ax1.transAxes,
+             fontsize=12, verticalalignment='top')
+    ax1.legend()
+    ax1.grid(True)
+
+    # Lower panel: Charge vs. Initial Location (log scale)
+    ax2.plot(locs_np, Q_theory_np, 'b-', label='Theory (Q0 exp(-dt/lifetime))')
+    ax2.plot(locs_np, charge_det_np, 'ro-', label='Deterministic (fluctuate=False)', markersize=4)
+    ax2.plot(locs_np, charge_sto_np, 'go-', label='Stochastic (fluctuate=True)', markersize=4)
+    # Plot variance band for dt > 0.
+    ax2.fill_between(locs_np[positive_mask.numpy()],
+                     Q_theory_np[positive_mask.numpy()] - std_np[positive_mask.numpy()],
+                     Q_theory_np[positive_mask.numpy()] + std_np[positive_mask.numpy()],
+                     color='gray', alpha=0.3, label='Theory ± 1σ (for dt > 0)')
+    # Mark the target location with a vertical dashed line.
+    ax2.axvline(x=target_chg, color='k', linestyle='--', label=f'Target = {target_chg}')
+    # Annotate with initial time, velocity, and lifetime.
+    ax2.text(0.05, 0.95,
+             f'Initial Time = {constant_time_chg}\nInitial charge = {Q0}'\
+             f'Velocity = {velocity_chg}\nLifetime = {lifetime_chg}',
+             transform=ax2.transAxes, fontsize=12, verticalalignment='top',
+             bbox=dict(facecolor='white', alpha=0.5, edgecolor='none'))
+    ax2.set_xlabel('Initial Location')
+    ax2.set_ylabel('Resulting Charge [log scale]')
+    ax2.set_yscale('log')
+    ax2.set_title('Resulting Charge vs. Initial Location')
+    ax2.legend()
+    ax2.grid(True)
+
+    mp = dt_det > 0
+    ax3.plot(dt_det[mp], dsigma_det[mp].numpy(), 'ro', label='Fluctuate=False', markersize=4)
+    ax3.plot(dt_sto[mp], dsigma_sto[mp].numpy(), 'g*', label='Fluctuate=True', markersize=4)
+    ax3.text(0.05, 0.95,
+             f'Initial Time = {constant_time_chg}\nInitial charge = {Q0}'\
+             f'Velocity = {velocity_chg}\nLifetime = {lifetime_chg}',
+             transform=ax3.transAxes, fontsize=12, verticalalignment='top',
+             bbox=dict(facecolor='white', alpha=0.5, edgecolor='none'))
+    ax3.set_title('Diffusion width vs. dt [dt>0]')
+    ax3.set_xlabel('dt [log]')
+    ax3.set_xscale('log')
+    ax3.set_ylabel('Diffusion width [log]')
+    ax3.set_yscale('log')
+    ax3.legend()
+    ax3.grid(True)
+
+    mn = dt_det < 0
+    ax4.plot(-dt_det[mn], dsigma_det[mn].numpy() + 1, 'ro', label='Fluctuate=False', markersize=4)
+    ax4.plot(-dt_sto[mn], dsigma_sto[mn].numpy() + 1, 'g*', label='Fluctuate=True', markersize=4)
+    ax4.text(0.05, 0.95,
+             f'Initial Time = {constant_time_chg}\nInitial charge = {Q0}'\
+             f'Velocity = {velocity_chg}\nLifetime = {lifetime_chg}',
+             transform=ax4.transAxes, fontsize=12, verticalalignment='top',
+             bbox=dict(facecolor='white', alpha=0.5, edgecolor='none'))
+    ax4.set_title('Diffusion width vs. dt [dt<0]')
+    ax4.set_xlabel('-dt [log]')
+    ax4.set_xscale('log')
+    ax4.set_ylabel('Diffusion width+1 [log]')
+    ax4.set_yscale('log')
+    ax4.legend()
+    ax4.grid(True)
+
+    plt.tight_layout()
+    plt.show()
+    fig.savefig('drifter.png')
+
+
+# If running this module directly, call the plotting function.
+if __name__ == '__main__':
+    pytest.main([__file__])
+    # plot_drift_times_vs_locs()
+    # plot_charge_vs_locs()
+    plot_drifter_simulations()

--- a/tests/drift/test_drifter.py
+++ b/tests/drift/test_drifter.py
@@ -1,7 +1,9 @@
 import pytest
 import torch
+from tred.drift import transport
 from tred.graph import Drifter
 
+import numpy as np
 import matplotlib.pyplot as plt
 
 @pytest.mark.parametrize("diffusion,lifetime,velocity,target,expect_error", [
@@ -176,201 +178,322 @@ def test_drifter_vaxis_out_of_range():
         drifter = Drifter(diffusion=0.1, lifetime=10.0, velocity=1.0, target=0.0, vaxis=10)
         drifter(None, None, torch.tensor([1., 2.]))
 
-def plot_drifter_simulations():
-    """
-    Combined plot with:
-      - Upper panel: Output Time vs. Initial Location (drift simulation).
-      - Lower panel: Resulting Charge vs. Initial Location (drift absorption).
-    """
-    # -----------------------
-    # Upper Panel: Drift Times vs. Locations
-    # -----------------------
-    # Simulation parameters for drift times
-    velocity = 2.0         # units: distance/time
-    diffusion = 0.1        # units: (length^2)/time (not directly plotted)
-    lifetime = 10.0        # units: time (affects absorption, not plotted)
-    target = 5.0           # drift target location along the drift axis
-    constant_time = 1.0    # constant initial time for all inputs
-    vaxis = 0              # drift is along the first dimension
-    fluctuate = False      # use deterministic mode for clarity
 
-    # Create a Drifter instance with the given parameters.
+@pytest.mark.parametrize("locs, times, velocity, target, tshift, expected", [
+    # Provided times, scalar tshift.
+    (torch.tensor([1.0, 3.0]), torch.tensor([0.5, 1.0]), 2.0, 5.0, 0.2,
+     torch.tensor([0.5, 1.0]) + transport(torch.tensor([1.0, 3.0]), 5.0, 2.0) - 0.2),
+    # No initial times, scalar tshift.
+    (torch.tensor([1.0, 3.0]), None, 2.0, 5.0, 0.2,
+     transport(torch.tensor([1.0, 3.0]), 5.0, 2.0) - 0.2),
+    # No initial times, 0D tensor tshift.
+    (torch.tensor([1.0, 3.0]), None, 2.0, 5.0, torch.tensor(0.2),
+     transport(torch.tensor([1.0, 3.0]), 5.0, 2.0) - 0.2),
+])
+def test_drifter_tshift_correction(locs, times, velocity, target, tshift, expected):
+    """
+    Test that Drifter applies the tshift correction correctly.
+    The output times should be: initial times + dt - tshift.
+    """
+    diffusion = 0.1
+    lifetime = 10.0
+    charge = None  # use default charge
+    drifter = Drifter(diffusion, lifetime, velocity, target, vaxis=0, tshift=tshift)
+    # Pass tshift as a keyword argument (requires Drifter.forward to forward it)
+    dsigma, dtime, dcharge, dlocs = drifter.forward(times, charge, locs)
+    assert torch.allclose(dtime, expected), f"Expected times {expected}, got {dtime}"
+
+
+@pytest.mark.parametrize("locs, times, velocity, target, drtoa, expected", [
+    # Provided times, scalar drtoa.
+    (torch.tensor([1.0, 3.0]), torch.tensor([0.5, 1.0]), 2.0, 5.0, 4.0,
+     torch.tensor([0.5, 1.0]) + transport(torch.tensor([1.0, 3.0]), 5.0, 2.0) - (4.0 / 2.0)),
+    # Provided times, 0D tensor drtoa.
+    (torch.tensor([1.0, 3.0]), torch.tensor([0.5, 1.0]), 2.0, 5.0, torch.tensor(4.0),
+     torch.tensor([0.5, 1.0]) + transport(torch.tensor([1.0, 3.0]), 5.0, 2.0) - (torch.tensor(4.0) / 2.0)),
+    # No initial times, scalar drtoa.
+    (torch.tensor([1.0, 3.0]), None, 2.0, 5.0, 4.0,
+     transport(torch.tensor([1.0, 3.0]), 5.0, 2.0) - (4.0 / 2.0)),
+    # No initial times, 0D tensor drtoa.
+    (torch.tensor([1.0, 3.0]), None, 2.0, 5.0, torch.tensor(4.0),
+     transport(torch.tensor([1.0, 3.0]), 5.0, 2.0) - (torch.tensor(4.0) / 2.0)),
+])
+def test_drifter_drtoa_correction(locs, times, velocity, target, drtoa, expected):
+    """
+    Test that Drifter applies the drtoa correction correctly.
+    The output times should be: initial times + dt - (drtoa/velocity).
+    """
+    diffusion = 0.1
+    lifetime = 10.0
+    charge = None  # use default charge
+    drifter = Drifter(diffusion, lifetime, velocity, target, vaxis=0, drtoa=drtoa)
+    dsigma, dtime, dcharge, dlocs = drifter.forward(times, charge, locs)
+    assert torch.allclose(dtime, expected), f"Expected times {expected}, got {dtime}"
+
+
+@pytest.mark.parametrize("locs, times, velocity, target, tshift", [
+    # Provided times, scalar tshift.
+    (torch.tensor([1.0, 3.0]), torch.tensor([0.5, 1.0]), 2.0, 5.0, 0.2),
+    # No initial times.
+    (torch.tensor([1.0, 3.0]), None, 2.0, 5.0, 0.2),
+])
+def test_drifter_tshift_interference(locs, times, velocity, target, tshift):
+    """
+    Check that providing tshift only affects the time output and does not alter sigma,
+    charge, or the updated locs.
+    """
+    diffusion = 0.1
+    lifetime = 10.0
+    charge = None
+    drifter_with = Drifter(diffusion, lifetime, velocity, target, vaxis=0, tshift=tshift)
+    drifter_without = Drifter(diffusion, lifetime, velocity, target, vaxis=0)
+    out_with = drifter_with.forward(times, charge, locs)
+    out_without = drifter_without.forward(times, charge, locs)
+    # Compare sigma, charge, and tail locs remain unchanged.
+    assert torch.allclose(out_with[0], out_without[0]), "Sigma should be unaffected by tshift."
+    assert torch.allclose(out_with[3], out_without[3]), "Tail locs should be unaffected by tshift."
+    assert torch.allclose(out_with[2], out_without[2]), "Charge should be unaffected by tshift."
+
+
+@pytest.mark.parametrize("locs, times, velocity, target, drtoa", [
+    # Provided times, scalar drtoa.
+    (torch.tensor([1.0, 3.0]), torch.tensor([0.5, 1.0]), 2.0, 5.0, 4.0),
+    # No initial times.
+    (torch.tensor([1.0, 3.0]), None, 2.0, 5.0, 4.0),
+])
+def test_drifter_drtoa_interference(locs, times, velocity, target, drtoa):
+    """
+    Check that providing drtoa only affects the time output and does not alter sigma,
+    charge, or the updated locs.
+    """
+    diffusion = 0.1
+    lifetime = 10.0
+    charge = None
+    drifter_with = Drifter(diffusion, lifetime, velocity, target, vaxis=0, drtoa=drtoa)
+    drifter_without = Drifter(diffusion, lifetime, velocity, target, vaxis=0, drtoa=drtoa)
+    out_with = drifter_with.forward(times, charge, locs)
+    out_without = drifter_without.forward(times, charge, locs)
+    # Compare sigma, charge, and tail locs remain unchanged.
+    assert torch.allclose(out_with[0], out_without[0]), "Sigma should be unaffected by drtoa."
+    assert torch.allclose(out_with[3], out_without[3]), "Tail locs should be unaffected by drtoa."
+    assert torch.allclose(out_with[2], out_without[2]), "Charge should be unaffected by drtoa."
+
+
+def test_drifter_mutually_exclusive_tshift_and_drtoa():
+    """
+    Test that Drifter.forward raises an error when both tshift and drtoa are provided.
+    """
+    locs = torch.tensor([1.0, 3.0])
+    diffusion = 0.1
+    velocity = 2.0
+    lifetime = 10.0
+    target = 5.0
+    times = torch.tensor([0.5, 1.0])
+    tshift = 0.2
+    drtoa = 4.0
+    charge = None
+    with pytest.raises(ValueError):
+        drifter = Drifter(diffusion, lifetime, velocity, target, vaxis=0, tshift=tshift, drtoa=drtoa)
+
+
+def plot_drift_time_vs_location():
+    """
+    Figure 1: Plots Output Time vs. Initial Location for drift simulation.
+    Now includes tshift and drtoa corrections on the same axis.
+    """
+    # Simulation parameters
+    velocity = 2.0
+    diffusion = 0.1
+    lifetime = 10.0
+    target = 5.0
+    constant_time = 1.0
+    tshift_value = 0.5  # Example correction shift in time
+    drtoa_value = 2.0   # Example drift displacement correction
+
+    # Initialize Drifter
     drifter = Drifter(diffusion=diffusion, lifetime=lifetime, velocity=velocity,
-                      target=target, vaxis=vaxis, fluctuate=fluctuate)
+                      target=target, vaxis=0, fluctuate=False)
+    drifter_tshift = Drifter(diffusion=diffusion, lifetime=lifetime, velocity=velocity,
+                      target=target, vaxis=0, fluctuate=False, tshift=tshift_value, drtoa=None)
+    drifter_drtoa = Drifter(diffusion=diffusion, lifetime=lifetime, velocity=velocity,
+                      target=target, vaxis=0, fluctuate=False, tshift=None, drtoa=drtoa_value)
 
-    # Generate a range of initial locations (for example, from 0 to 10)
+    # Generate initial locations
     initial_locs = torch.linspace(0, 10, 100)
-    # Create a constant initial time tensor.
     initial_time = torch.full_like(initial_locs, constant_time)
-    # Set a constant charge (e.g., 1000 electrons) for each point.
     initial_charge = torch.full_like(initial_locs, 1000, dtype=torch.float32)
 
-    # Preserve the initial locations (input independent variable)
-    input_locs = initial_locs.clone()
+    # Compute drift time for different cases
+    _, dtime_no_correction, _, _ = drifter.forward(initial_time, initial_charge, initial_locs)
+    _, dtime_tshift, _, _ = drifter_tshift.forward(initial_time, initial_charge, initial_locs)
+    _, dtime_drtoa, _, _ = drifter_drtoa.forward(initial_time, initial_charge, initial_locs)
 
-    # Call Drifter.forward.
-    # Drifter.forward returns (dsigma, dtime, dcharge, dtail)
-    dsigma, dtime, dcharge, dtail = drifter.forward(initial_time, initial_charge, initial_locs)
-
-    # Convert tensors to numpy arrays for plotting.
-    input_locs_np = input_locs.numpy()
-    dtime_np = dtime.numpy()
-
-    # -----------------------
-    # Lower Panel: Charge vs. Locations
-    # -----------------------
-    # Simulation parameters for charge absorption
-    velocity_chg = 2.0     # units: distance/time
-    diffusion_chg = 0.1    # required by Drifter, though not used for theory curve
-    lifetime_chg = 2.0     # absorption lifetime (time units)
-    target_chg = 5.0       # drift target location along the drift axis
-    Q0 = 1000.0            # initial charge (electrons)
-    constant_time_chg = 0.0  # constant initial time for all inputs
-    vaxis_chg = 0          # drift along the first dimension
-
-    # Create two Drifter instances: one deterministic and one stochastic.
-    drifter_det = Drifter(diffusion=diffusion_chg, lifetime=lifetime_chg, velocity=velocity_chg,
-                          target=target_chg, vaxis=vaxis_chg, fluctuate=False)
-    drifter_sto = Drifter(diffusion=diffusion_chg, lifetime=lifetime_chg, velocity=velocity_chg,
-                          target=target_chg, vaxis=vaxis_chg, fluctuate=True)
-
-    # Generate a range of initial locations.
-    initial_locs_chg = torch.linspace(0, 10, 100)
-    # Create a constant initial time for all inputs.
-    initial_time_chg = torch.full_like(initial_locs_chg, constant_time_chg)
-    # Create a tensor for the initial charge.
-    initial_charge_chg = torch.full_like(initial_locs_chg, Q0, dtype=torch.float32)
-
-    # Compute the theoretical drift time for each location.
-    dt = (target_chg - initial_locs_chg) / velocity_chg
-    # Compute the theoretical surviving charge: Q_theory = Q0 * exp(- dt / lifetime)
-    Q_theory = Q0 * torch.exp(- dt / lifetime_chg)
-    # For dt > 0, compute the loss fraction and standard deviation.
-    L = 1 - torch.exp(- dt / lifetime_chg)
-    variance = Q0 * L * (1 - L)
-    std_dev = torch.sqrt(variance)
-    positive_mask = dt > 0
-
-    # Run the drift simulation using Drifter.forward.
-    # forward returns (dsigma, dtime, dcharge, dtail)
-    dsigma_det, dt_det, charge_det, _ = drifter_det.forward(initial_time_chg, initial_charge_chg, initial_locs_chg)
-    dsigma_sto, dt_sto, charge_sto, _ = drifter_sto.forward(initial_time_chg, initial_charge_chg, initial_locs_chg)
-
-    # Convert tensors to numpy for plotting.
-    locs_np = initial_locs_chg.numpy()
-    Q_theory_np = Q_theory.numpy()
-    charge_det_np = charge_det.numpy()
-    charge_sto_np = charge_sto.numpy()
-    std_np = std_dev.numpy()
-
-    dt_det_np = dt_det.numpy()
-    dt_sto_np = dt_sto.numpy()
-    dsigma_det_p1 = dsigma_det.numpy() + 1
-    dsigma_sto_p1 = dsigma_sto.numpy() + 1
+    # Convert tensors to numpy for plotting
+    input_locs_np = initial_locs.numpy()
+    dtime_no_correction_np = dtime_no_correction.numpy()
+    dtime_tshift_np = dtime_tshift.numpy()
+    dtime_drtoa_np = dtime_drtoa.numpy()
 
     # -----------------------
-    # Create a figure with 3 rows, 2 columns
-    #   Row 1: ax1 spans columns 1-2
-    #   Row 2: ax2 spans columns 1-2
-    #   Row 3: ax3 (col 1), ax4 (col 2)
+    # Create a single-axis figure
     # -----------------------
-    fig = plt.figure(figsize=(10, 14))
+    fig, ax1 = plt.subplots(figsize=(8, 6))
 
-    # Top row (row=1), spanning columns 1 and 2
-    ax1 = fig.add_subplot(3, 2, (1, 2))
-    # Second row (row=2), spanning columns 1 and 2
-    ax2 = fig.add_subplot(3, 2, (3, 4))
-    # Third row, left column (row=3, col=1)
-    ax3 = fig.add_subplot(3, 2, 5)
-    # Third row, right column (row=3, col=2)
-    ax4 = fig.add_subplot(3, 2, 6)
+    # Plot all three drift time variations on one axis
+    ax1.plot(input_locs_np, dtime_no_correction_np, 'bo-', label='No Correction')
+    ax1.plot(input_locs_np, dtime_tshift_np, 'r--', label=f'tshift = {tshift_value}')
+    ax1.plot(input_locs_np, dtime_drtoa_np, 'g-.', label=f'drtoa = {drtoa_value}')
 
-    # # -----------------------
-    # # Create Combined Figure with Two Subplots
-    # # -----------------------
-    # fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(10, 6*3))
+    # Reference lines
+    ax1.axvline(x=target, color='black', linestyle='--', label=f'Target = {target}')
+    ax1.axhline(y=constant_time, color='gray', linestyle='--', label=f'Initial Time = {constant_time}')
 
-    # Upper panel: Drift times vs. Initial Location
-    ax1.plot(input_locs_np, dtime_np, 'bo-', label='Output Time')
+    # Labels and title
     ax1.set_xlabel('Initial Location')
     ax1.set_ylabel('Output Time')
     ax1.set_title('Output Time vs. Initial Location (Drift Simulation)')
-    # Mark the target location with a vertical dashed line.
-    ax1.axvline(x=target, color='r', linestyle='--', label=f'Target = {target}')
-    # Mark the constant initial time with a horizontal dashed line.
-    ax1.axhline(y=constant_time, color='g', linestyle='--', label=f'Initial Time = {constant_time}')
-    # Add text annotations for velocity and target information.
-    ax1.text(0.05, 0.95, f'Velocity: {velocity}', transform=ax1.transAxes,
-             fontsize=12, verticalalignment='top')
-    ax1.text(0.05, 0.90, f'Target: {target}', transform=ax1.transAxes,
-             fontsize=12, verticalalignment='top')
     ax1.legend()
     ax1.grid(True)
 
-    # Lower panel: Charge vs. Initial Location (log scale)
-    ax2.plot(locs_np, Q_theory_np, 'b-', label='Theory (Q0 exp(-dt/lifetime))')
-    ax2.plot(locs_np, charge_det_np, 'ro-', label='Deterministic (fluctuate=False)', markersize=4)
-    ax2.plot(locs_np, charge_sto_np, 'go-', label='Stochastic (fluctuate=True)', markersize=4)
-    # Plot variance band for dt > 0.
-    ax2.fill_between(locs_np[positive_mask.numpy()],
-                     Q_theory_np[positive_mask.numpy()] - std_np[positive_mask.numpy()],
-                     Q_theory_np[positive_mask.numpy()] + std_np[positive_mask.numpy()],
-                     color='gray', alpha=0.3, label='Theory ± 1σ (for dt > 0)')
-    # Mark the target location with a vertical dashed line.
-    ax2.axvline(x=target_chg, color='k', linestyle='--', label=f'Target = {target_chg}')
-    # Annotate with initial time, velocity, and lifetime.
-    ax2.text(0.05, 0.95,
-             f'Initial Time = {constant_time_chg}\nInitial charge = {Q0}'\
-             f'Velocity = {velocity_chg}\nLifetime = {lifetime_chg}',
-             transform=ax2.transAxes, fontsize=12, verticalalignment='top',
-             bbox=dict(facecolor='white', alpha=0.5, edgecolor='none'))
-    ax2.set_xlabel('Initial Location')
-    ax2.set_ylabel('Resulting Charge [log scale]')
-    ax2.set_yscale('log')
-    ax2.set_title('Resulting Charge vs. Initial Location')
-    ax2.legend()
-    ax2.grid(True)
+    # -----------------------
+    # Add velocity text annotation
+    # -----------------------
+    text_x = 0.05  # Position relative to axis
+    text_y = 0.90  # Position relative to axis
+    ax1.text(text_x, text_y, f'Velocity = {velocity} units/time',
+             transform=ax1.transAxes, fontsize=12, verticalalignment='top',
+             bbox=dict(facecolor='white', alpha=0.7, edgecolor='none'))
 
-    mp = dt_det > 0
-    ax3.plot(dt_det[mp], dsigma_det[mp].numpy(), 'ro', label='Fluctuate=False', markersize=4)
-    ax3.plot(dt_sto[mp], dsigma_sto[mp].numpy(), 'g*', label='Fluctuate=True', markersize=4)
-    ax3.text(0.05, 0.95,
-             f'Initial Time = {constant_time_chg}\nInitial charge = {Q0}'\
-             f'Velocity = {velocity_chg}\nLifetime = {lifetime_chg}',
-             transform=ax3.transAxes, fontsize=12, verticalalignment='top',
-             bbox=dict(facecolor='white', alpha=0.5, edgecolor='none'))
-    ax3.set_title('Diffusion width vs. dt [dt>0]')
-    ax3.set_xlabel('dt [log]')
+    # Show plot
+    plt.show()
+    plt.savefig('drifter_dt.png')
+
+
+def plot_charge_vs_location():
+    """
+    Figure 2: Plots Resulting Charge vs. Initial Location for drift absorption.
+    """
+    # Simulation parameters
+    velocity = 2.0
+    diffusion = 0.1
+    lifetime = 2.0
+    target = 5.0
+    Q0 = 1000.0
+
+    drifter_det = Drifter(diffusion=diffusion, lifetime=lifetime, velocity=velocity, target=target, vaxis=0, fluctuate=False)
+    drifter_sto = Drifter(diffusion=diffusion, lifetime=lifetime, velocity=velocity, target=target, vaxis=0, fluctuate=True)
+
+    initial_locs = torch.linspace(0, 10, 100)
+    initial_time = torch.full_like(initial_locs, 0.0)
+    initial_charge = torch.full_like(initial_locs, Q0, dtype=torch.float32)
+
+    dt = (target - initial_locs) / velocity
+    Q_theory = Q0 * torch.exp(- dt / lifetime)
+    positive_mask = dt > 0
+    variance = Q0 * (1 - torch.exp(- dt / lifetime)) * torch.exp(- dt / lifetime)
+    std_dev = torch.sqrt(variance)
+
+    _, _, charge_det, _ = drifter_det.forward(initial_time, initial_charge, initial_locs)
+    _, _, charge_sto, _ = drifter_sto.forward(initial_time, initial_charge, initial_locs)
+
+    slope_det, _ = np.polyfit(dt[positive_mask].numpy(),
+                                  np.log(charge_det[positive_mask].numpy()), 1)
+    slope_sto, _ = np.polyfit(dt[positive_mask].numpy(),
+                                  np.log(charge_sto[positive_mask].numpy()), 1)
+
+    plt.figure(figsize=(8, 6))
+    plt.plot(initial_locs.numpy(), Q_theory.numpy(), 'b-', label='Theory (Q0 exp(-dt/lifetime))')
+    plt.plot(initial_locs.numpy(), charge_det.numpy(), 'ro-', label='Deterministic', markersize=4)
+    plt.plot(initial_locs.numpy(), charge_sto.numpy(), 'g*-', label='Stochastic', markersize=4)
+    plt.fill_between(initial_locs.numpy()[positive_mask.numpy()],
+                     (Q_theory - std_dev)[positive_mask].numpy(),
+                     (Q_theory + std_dev)[positive_mask].numpy(),
+                     color='gray', alpha=0.3, label='Theory ± 1σ')
+
+
+    plt.axvline(x=target, color='k', linestyle='--', label=f'Target = {target}')
+    plt.xlabel('Initial Location')
+    plt.ylabel('Resulting Charge [log scale]')
+    plt.yscale('log')
+    plt.title('Resulting Charge vs. Initial Location')
+    plt.legend()
+
+    ax1 = plt.gca()
+    text_x = 0.05
+    text_y = 0.95
+    ax1.text(text_x, text_y, f'Exponent from fit, deterministic, {slope_det:.3f}\n'
+             f'Exponent from fit, stochastic, {slope_sto:.3f}\n'
+             f'1/lifetime (fixed configuration)  {1./lifetime:.3f}',
+             transform=ax1.transAxes, fontsize=12, verticalalignment='top',
+             bbox=dict(facecolor='white', alpha=0.7, edgecolor='none'))
+
+    plt.grid(True)
+    plt.show()
+
+    plt.savefig('drifter_charge.png')
+
+
+def plot_diffusion_width():
+    """
+    Figure 3: Plots Diffusion Width vs. Drift Time with two subplots (dt > 0 and dt < 0).
+    """
+    # Simulation parameters
+    velocity = 1.0
+    diffusion = 0.1
+    lifetime = 2.0
+    target = 5.0
+    Q0 = 1000.0
+
+    drifter_det = Drifter(diffusion=diffusion, lifetime=lifetime, velocity=velocity, target=target, vaxis=0, fluctuate=False)
+    drifter_sto = Drifter(diffusion=diffusion, lifetime=lifetime, velocity=velocity, target=target, vaxis=0, fluctuate=True)
+
+    initial_locs = torch.linspace(0, 10, 100)
+    initial_time = torch.full_like(initial_locs, 0.0)
+    initial_charge = torch.full_like(initial_locs, Q0, dtype=torch.float32)
+
+    dsigma_det, dt_det, _, _ = drifter_det.forward(initial_time, initial_charge, initial_locs)
+    dsigma_sto, dt_sto, _, _ = drifter_sto.forward(initial_time, initial_charge, initial_locs)
+
+    positive_mask = dt_det > 0
+    negative_mask = dt_det < 0
+
+    slope, intercept = np.polyfit(np.log(dt_det[positive_mask].numpy()),
+                                  np.log(dsigma_det[positive_mask].numpy()), 1)
+
+    # Create a figure with two subplots
+    fig, (ax3, ax4) = plt.subplots(1, 2, figsize=(12, 6))
+
+    # Left panel: dt > 0
+    ax3.plot(dt_det[positive_mask].numpy(), dt_det[positive_mask].numpy()**slope*np.exp(intercept), '--', label=f'Fit, Power {slope:.2f}')
+    ax3.plot(dt_det[positive_mask].numpy(), dsigma_det[positive_mask].numpy(), 'ro', label='Fluctuate=False', markersize=4)
+    ax3.plot(dt_sto[positive_mask].numpy(), dsigma_sto[positive_mask].numpy(), 'g*', label='Fluctuate=True', markersize=4)
     ax3.set_xscale('log')
-    ax3.set_ylabel('Diffusion width [log]')
     ax3.set_yscale('log')
+    ax3.set_xlabel('dt [log]')
+    ax3.set_ylabel('Diffusion width [log]')
+    ax3.set_title('Diffusion Width vs. dt [dt > 0]')
     ax3.legend()
     ax3.grid(True)
 
-    mn = dt_det < 0
-    ax4.plot(-dt_det[mn], dsigma_det[mn].numpy() + 1, 'ro', label='Fluctuate=False', markersize=4)
-    ax4.plot(-dt_sto[mn], dsigma_sto[mn].numpy() + 1, 'g*', label='Fluctuate=True', markersize=4)
-    ax4.text(0.05, 0.95,
-             f'Initial Time = {constant_time_chg}\nInitial charge = {Q0}'\
-             f'Velocity = {velocity_chg}\nLifetime = {lifetime_chg}',
-             transform=ax4.transAxes, fontsize=12, verticalalignment='top',
-             bbox=dict(facecolor='white', alpha=0.5, edgecolor='none'))
-    ax4.set_title('Diffusion width vs. dt [dt<0]')
-    ax4.set_xlabel('-dt [log]')
+    # Right panel: dt < 0
+    ax4.plot(-dt_det[negative_mask].numpy(), dsigma_det[negative_mask].numpy() + 1, 'ro', label='Fluctuate=False', markersize=4)
+    ax4.plot(-dt_sto[negative_mask].numpy(), dsigma_sto[negative_mask].numpy() + 1, 'g*', label='Fluctuate=True', markersize=4)
     ax4.set_xscale('log')
-    ax4.set_ylabel('Diffusion width+1 [log]')
     ax4.set_yscale('log')
+    ax4.set_xlabel('-dt [log]')
+    ax4.set_ylabel('Diffusion width + 1 [log]')
+    ax4.set_title('Diffusion Width vs. dt [dt < 0]')
     ax4.legend()
     ax4.grid(True)
 
     plt.tight_layout()
     plt.show()
-    fig.savefig('drifter.png')
+    plt.savefig('drifter_diffwidth.png')
 
 
 # If running this module directly, call the plotting function.
 if __name__ == '__main__':
     pytest.main([__file__])
-    # plot_drift_times_vs_locs()
-    # plot_charge_vs_locs()
-    plot_drifter_simulations()
+    plot_drift_time_vs_location()
+    plot_charge_vs_location()
+    plot_diffusion_width()

--- a/tests/drift/test_drifter.py
+++ b/tests/drift/test_drifter.py
@@ -1,0 +1,175 @@
+import pytest
+import torch
+from tred.graph import Drifter
+
+@pytest.mark.parametrize("diffusion,lifetime,velocity,target,expect_error", [
+    (None, 10.0, 1.0, 0.0, True),      # diffusion is None
+    (0.1, None, 1.0, 0.0, True),       # lifetime is None
+    (0.1, 10.0, None, 0.0, True),      # velocity is None
+    (0.1, 10.0, 1.0, None, True),      # target is None
+    (0.1, 10.0, 1.0, 5.0, False),      # all valid
+    (torch.tensor([0.1, 0.1, 0.1]), 10.0, 1.0, 5.0, False),      # all valid
+])
+def test_drifter_init_validation(diffusion, lifetime, velocity, target, expect_error):
+    """
+    Test that Drifter raises ValueError if any required argument is missing,
+    and constructs successfully otherwise.
+    """
+    if expect_error:
+        with pytest.raises(ValueError):
+            Drifter(diffusion, lifetime, velocity, target=target)
+    else:
+        d = Drifter(diffusion, lifetime, velocity, target=target)
+        assert isinstance(d, Drifter)
+
+
+def test_drifter_forward_no_head():
+    """
+    Test Drifter forward pass (no head). Check shapes and basic value correctness.
+    """
+    # Construct Drifter
+    diffusion = 0.1
+    lifetime = 10.0
+    velocity = 2.0
+    target = 5.0
+    vaxis = 0
+    drifter = Drifter(diffusion, lifetime, velocity, target=target, vaxis=vaxis)
+
+    # Prepare inputs
+    locs = torch.tensor([1.0, 3.0])
+    time = torch.tensor([0.0, 1.0])  # initial times
+    charge = torch.tensor([100.0, 200.0])
+
+    # Run forward
+    dsigma, dtime, dcharge, dtail = drifter(time, charge, locs)
+
+    # Check shapes
+    assert dsigma.shape == locs.shape, "Sigma should match shape of locs (after drifting)."
+    assert dtime.shape == time.shape, "Time output should match the input shape."
+    assert dcharge.shape == charge.shape, "Charge output should match input shape."
+    assert dtail.shape == locs.shape, "Tail output should match input locs shape."
+
+    # Check that tail is set to target along vaxis
+    assert torch.allclose(dtail, torch.full_like(locs, target)), (
+        f"Drifter should set locs along axis={vaxis} to {target}"
+    )
+
+    # Check that time is incremented by dt
+    dt = (target - locs) / velocity
+    assert torch.allclose(dtime, time + dt), "Time should be incremented by drift time."
+
+    # Check that charge is reduced (exponential factor)
+    expected_charge = charge * torch.exp(-dt / lifetime)
+    assert torch.allclose(dcharge, expected_charge), "Charge should follow exponential quenching."
+
+
+def test_drifter_forward_with_head():
+    """
+    Test Drifter forward pass when a head location is provided.
+    Drifter should then return 5 outputs: (dsigma, dtime, dcharge, dtail, dhead).
+    """
+    # Construct Drifter
+    #diffusion = torch.tensor([0.2, 0.2])
+    diffusion = [0.2, 0.2]
+    lifetime = 5.0
+    velocity = 1.0
+    target = 0.0
+    drifter = Drifter(diffusion, lifetime, velocity, target=target, vaxis=1)
+
+    # Prepare inputs (2D)
+    tail = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+    head = torch.tensor([[1.0, 2.0], [3.0, 5.0]])
+    time = torch.tensor([0.1, 1.2])
+    charge = torch.tensor([300.0, 400.0])
+
+    # Run forward
+    outputs = drifter(time, charge, tail, head=head)
+    assert len(outputs) == 5, "When 'head' is given, Drifter should return five outputs."
+    dsigma, dtime, dcharge, dtail, dhead = outputs
+
+    # Check shapes
+    assert dsigma.shape == tail.shape, "Sigma shape should match shape of tail."
+    assert dtime.shape == time.shape, "Time shape should match the shape of input times."
+    assert dcharge.shape == charge.shape, "Charge shape should match the shape of input charge."
+    assert dtail.shape == tail.shape, "dtail shape should match tail."
+    assert dhead.shape == head.shape, "dhead shape should match head."
+
+    # For vaxis=1, we expect tail[:,1] to become target
+    assert torch.allclose(dtail[:, 1], torch.full((2,), target)), (
+        "Drifter should set locs along axis=1 to target"
+    )
+
+    # dhead = head + (dtail - tail) => it shifts "head" by the same amount that "tail" was shifted
+    expected_dhead = head + (dtail - tail)
+    assert torch.allclose(dhead, expected_dhead), (
+        "dhead should reflect the same shift from tail -> dtail"
+    )
+
+
+def test_drifter_negative_velocity():
+    """
+    Test negative velocity scenario. If velocity is negative but target - loc > 0,
+    the drift time is negative, so sigma should shrink or go to zero.
+    """
+    drifter = Drifter(diffusion=0.1, lifetime=10.0, velocity=-2.0, target=5.0)
+    locs = torch.tensor([2.0, 3.0])
+    time = torch.tensor([0.0, 0.0])
+    charge = torch.tensor([1000.0, 1000.0])
+
+    dsigma, dtime, dcharge, dtail = drifter(time, charge, locs)
+
+    # dt should be negative => times get incremented by negative dt
+    assert torch.all(dtime < 0), (
+        f"For negative velocity with this setup, drift times are negative: got {dtime}."
+    )
+    # Sigma for negative dt is forced to zero in underlying drift code
+    assert torch.allclose(dsigma, torch.tensor(0.0)), "Sigma should vanish (or clamp to zero) for negative dt."
+    # Charge for negative dt can actually go up if using pure drift math, but
+    # here we check that it is not forcibly increased. The drift() function
+    # uses an exponential that can increase for negative dt. If it’s clamped,
+    # we’d see an increase, but test that it's not decreased in an unexpected way:
+    assert torch.all(dcharge >= 1000.0), (
+        f"For negative dt, charge should not be forcibly decreased. Got {dcharge}."
+    )
+    # dtail should be set to the target, though it's physically contradictory
+    # that we ended up with negative dt. The drift() function straightforwardly
+    # sets locs[vaxis] to target.
+    assert torch.allclose(dtail, torch.full_like(locs, 5.0)), (
+        "Tail location should still be forced to target in code."
+    )
+
+
+def test_drifter_fluctuate():
+    """
+    Test that Drifter's fluctuate argument is properly registered.
+    We won't do a deep check of statistical distribution, but we can
+    check that the Drifter passes along the flag without error.
+    """
+    drifter = Drifter(diffusion=0.1, lifetime=10.0, velocity=2.0,
+                      target=5.0, vaxis=0, fluctuate=True)
+    locs = torch.tensor([1.0, 2.0, 3.0])
+    time = torch.tensor([0.0, 0.5, 1.0])
+    charge = torch.tensor([100.0, 200.0, 300.0])
+
+    # Because fluctuate=True triggers a Binomial draw inside drift(),
+    # the result is random. We'll just make sure it runs and returns
+    # the correct shape.
+    dsigma, dtime, dcharge, dtail = drifter(time, charge, locs)
+
+    assert dsigma.shape == locs.shape
+    assert dtime.shape == time.shape
+    assert dcharge.shape == charge.shape
+    assert dtail.shape == locs.shape
+    # We expect at most the same or smaller charge values:
+    #  There's a random variation, but on average it should be less.
+    assert torch.all(dcharge <= charge), "Fluctuating charges should not exceed initial values."
+
+
+def test_drifter_vaxis_out_of_range():
+    """
+    If vaxis is out of range for the given locs, the underlying drift
+    function should raise an error.
+    """
+    with pytest.raises(ValueError, match="illegal vector axis"):
+        drifter = Drifter(diffusion=0.1, lifetime=10.0, velocity=1.0, target=0.0, vaxis=10)
+        drifter(None, None, torch.tensor([1., 2.]))

--- a/tests/drift/test_transport.py
+++ b/tests/drift/test_transport.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import torch
+
+from tred.drift import transport
+
+def test_transport():
+    # Test 1: Basic positive velocity
+    locs = torch.tensor([0.0, 1.0, 2.0])
+    target = torch.tensor(4.0)
+    velocity = torch.tensor(2.0)
+    expected = torch.tensor([2.0, 1.5, 1.0])
+    assert torch.allclose(transport(locs, target, velocity), expected), "Test 1 failed"
+
+    # Test 2: Basic negative velocity
+    locs = torch.tensor([5.0, 3.0, 1.0])
+    target = torch.tensor(-1.0)
+    velocity = torch.tensor(-2.0)
+    expected = torch.tensor([3.0, 2.0, 1.0])
+    assert torch.allclose(transport(locs, target, velocity), expected), "Test 2 failed"
+
+    # Test 3: Zero velocity (Should handle inf or error)
+    locs = torch.tensor([1.0, 2.0, 3.0])
+    target = torch.tensor(5.0)
+    velocity = torch.tensor(0.0)
+    try:
+        result = transport(locs, target, velocity)
+        assert torch.isinf(result).all(), "Test 3 failed: Expected infinity"
+    except ZeroDivisionError:
+        pass  # Also acceptable if an exception is raised
+
+    # Test 4: Target same as locations (Zero time expected)
+    locs = torch.tensor([3.0, 3.0, 3.0])
+    target = torch.tensor(3.0)
+    velocity = torch.tensor(5.0)
+    expected = torch.tensor([0.0, 0.0, 0.0])
+    assert torch.allclose(transport(locs, target, velocity), expected), "Test 4 failed"
+
+    # Test 5: Fractional results
+    locs = torch.tensor([1.5, 2.5, 3.5])
+    target = torch.tensor(5.0)
+    velocity = torch.tensor(1.5)
+    expected = torch.tensor([2.3333, 1.6667, 1.0])
+    assert torch.allclose(transport(locs, target, velocity), expected, atol=1e-4), "Test 5 failed"
+
+    # Test 6: Negative locations
+    locs = torch.tensor([-2.0, -1.0, 0.0])
+    target = torch.tensor(3.0)
+    velocity = torch.tensor(2.0)
+    expected = torch.tensor([2.5, 2.0, 1.5])
+    assert torch.allclose(transport(locs, target, velocity), expected), "Test 6 failed"
+
+    # Test 7: Broadcasting support
+    locs = torch.tensor([0.0, 1.0, 2.0])
+    target = torch.tensor(4.0)  # Scalar as tensor
+    velocity = torch.tensor(2.0)  # Scalar as tensor
+    expected = torch.tensor([2.0, 1.5, 1.0])
+    assert torch.allclose(transport(locs, target, velocity), expected), "Test 7 failed"
+
+    print("All tests passed!")
+
+test_transport()


### PR DESCRIPTION
- Fixed several bugs in handling the input shape.
- Redefined `dtail` and `dhead` to eliminated the ambiguity. Now they are distinct by the distance to anode plane and ready for the input of rasterization.
- Added a two optional arguments to account for time differences from response plane to anode plane.
- Added a few unit tests and analysis plots.