### PR TITLE
Rasterization

### DIFF
--- a/src/tred/graph.py
+++ b/src/tred/graph.py
@@ -132,8 +132,9 @@ class Raster(nn.Module):
         constant(self, 'velocity', velocity)
         constant(self, 'grid_spacing', grid_spacing)
         constant(self, 'nsigma', nsigma)
+
         self._pdims = pdims or ()
-        self._tdim = tdim
+        self._tdim = tdim if tdim>=0 else len(self._pdims) + 1 + tdim
 
     def _time_diff(self, tail, head=None):
         """
@@ -162,6 +163,10 @@ class Raster(nn.Module):
         if self._pdims:
             old_tdim = (set(range(ndims)) - set(self._pdims)).pop()
             axes = list(iter(self._pdims))
+            # Method insert always inserts new elements in front of the position;
+            # Insertion position is desired when tdim >= 0;
+            # For tdim < 0, data fall behind the desired position counting from the back;
+            # A correction is made in __init__; vdim + tdim for tdim<0
             axes.insert(self._tdim, old_tdim)
             point = point[:, axes]
 

--- a/src/tred/graph.py
+++ b/src/tred/graph.py
@@ -26,6 +26,7 @@ from .blocking import Block
 from .drift import drift
 from .util import debug, tenstr
 from .raster.depos import binned as raster_depos
+from .raster.steps import compute_qeff
 
 from .types import index_dtype
 from .sparse import chunkify
@@ -36,9 +37,18 @@ import torch
 import torch.nn as nn
 
 def raster_steps(*args,**kwds):
-    raise NotImplementedError("Yousen, make raster.steps.function, import it as tred.graph.raster_steps and delete this temporary function")
-
-
+    # raise NotImplementedError("Yousen, make raster.steps.function, import it as tred.graph.raster_steps and delete this temporary function")
+    # rasters, offsets = raster_steps(self.grid_spacing, tail, head, sigma, charge, nsigma=self.nsigma)
+    # args[0] : grid_spaing
+    # args[1] : tail, X0
+    # args[2] : tail, X1
+    # args[3] : sigma
+    # args[4] : charge, Q
+    # kwds['nsigma] : nsigma, scalar
+    return compute_qeff(grid_spacing=args[0], X0=args[1], X1=args[2],
+                        Sigma=args[3], Q=args[4],
+                        n_sigma=(kwds['nsigma'], kwds['nsigma'], kwds['nsigma']),
+                        origin=(0,0,0), method='gauss_legendre', npoints=(2,2,2))
 
 def param(thing, dtype=torch.float32):
     if isinstance(thing, torch.Tensor):
@@ -158,6 +168,7 @@ class Raster(nn.Module):
 
         head = self._transform(head, time)
         rasters, offsets = raster_steps(self.grid_spacing, tail, head, sigma, charge, nsigma=self.nsigma)
+
         return Block(location = offsets, data=rasters)
 
 

--- a/tests/effq/test_raster_steps.py
+++ b/tests/effq/test_raster_steps.py
@@ -1,0 +1,50 @@
+import sys
+import numpy as np
+
+import torch
+import logging
+import tred.graph as tg
+
+def test_compute_qeff_raster_steps(level=None):
+    local_logger = logging.getLogger('test_eval_qeff_raster_steps')
+    if level:
+        local_logger.setLevel(level)
+
+    # Test the raster_steps wrapper. Note: raster_steps uses fixed npoints=(2,2,2)
+    grid_spacing = (0.1, 0.1, 0.1)
+    tail = torch.tensor([(0.4, 2.4, 3.4)])
+    head = torch.tensor([(0.6, 2.6, 3.6)])
+    sigma = torch.tensor([(0.5, 0.5, 0.5)])
+    charge = torch.tensor([(1,)])
+    nsigma = 0.7
+
+    effq, offset = tg.raster_steps(grid_spacing, tail, head, sigma, charge, nsigma=nsigma)
+
+    q_sum = torch.sum(effq).item()
+    qint = 0.313723 # from mathematica
+    local_logger.debug(f'Raster steps test passed, computed integral sum: {q_sum}')
+    assert q_sum > 0, "Raster steps computed integral should be positive"
+    assert np.isclose(q_sum, qint, rtol=1E-5), f'Raster steps computed integral does not match predefined value {qint}.'
+
+def main():
+    print('-------- test_compute_qeff ---------')
+    test_compute_qeff_raster_steps()
+
+
+if __name__ == '__main__':
+    try:
+        opt = sys.argv[1]
+        if opt.lower() == 'debug':
+            logging.basicConfig(level=logging.DEBUG)
+        elif opt.lower() == 'warning':
+            logging.basicConfig(level=logging.WARNING)
+        elif opt.lower() == 'info':
+            logging.basicConfig(level=logging.INFO)
+        else:
+            print('Usage: test_grid.py [debug|warning|info]')
+            exit(-1)
+    except IndexError:
+        # logging.basicConfig(level=logging.DEBUG)
+        print('To use system default logging level')
+
+    main()

--- a/tests/effq/test_raster_steps.py
+++ b/tests/effq/test_raster_steps.py
@@ -1,5 +1,6 @@
 import sys
 import numpy as np
+import matplotlib.pyplot as plt
 
 import torch
 import logging
@@ -50,13 +51,112 @@ def test_transform(level=None):
     p = raster._transform(points, time)
     assert p.equal(torch.tensor([3, 2, 5]).view(1,3)), f'points after transformation is {p}.'
 
+def test_time_diff():
+    """Test the _time_diff method.
+        Test _time_diff with head as None."""
+    velocity = 2.0
+    grid_spacing = torch.tensor([0.5])
+    raster = tg.Raster(velocity, grid_spacing, pdims=())
+    tail = torch.tensor([0.0, 1.0, 2.0])
+    head = torch.tensor([2.0, 3.0, 4.0])
+    result = raster._time_diff(tail, head)
+    expected = (tail - head) / velocity
+    assert torch.equal(result, expected), f"expected {expected}, result {result}"
+
+    grid_spacing = torch.tensor([0.5, 0.5, 0.5])
+    raster = tg.Raster(velocity, grid_spacing, pdims=(1,2))
+    tail = torch.tensor([[0.0, 1.0, 2.0]])
+    head = torch.tensor([[2.0, 3.0, 4.0]])
+    result = raster._time_diff(tail, head)
+    expected = (tail[:,0]-head[:,0]) / velocity
+    assert torch.equal(result, expected)
+
+    result = raster._time_diff(torch.tensor([1.0, 2.0, 3.0]))
+    assert result is None
+
+
+def test_drift_raster_positions():
+    # Define parameters
+    time = 1
+    charge = torch.tensor([10, 10])# Placeholder value
+    target = 3
+    velocity = 2.0
+    drifter = tg.Drifter(diffusion=[0.1, 0.1], lifetime=10, velocity=velocity, target=target)
+
+    tail = torch.tensor([[1, 2], [-1, 1]])
+    head = tail.clone().detach()
+    head[:,0] = head[:,0] - 1
+    head[:,1] = head[:,1] - 2
+    _, dtime, _, dtail, dhead = drifter(time, charge, tail, head)
+
+    # Create the plot
+    # plt.figure(figsize=(8, 6))
+    nrows = 2
+    ncols = 1
+    fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(8*ncols, 6*nrows))
+
+    # Plot Raster data points
+    for i in range(tail.size(0)):
+        if i == 0:
+            axes[0].plot(tail[i,0], tail[i,1], color='blue', label='tail', marker='o', linestyle='-')
+            axes[0].plot(head[i,0], head[i,1], color='red', label='head', marker='o', linestyle='-')
+            axes[0].plot(dtail[i,0], dtail[i,1], color='blue', label='dtail', marker='x', linestyle='-')
+            axes[0].plot(dhead[i,0], dhead[i,1], color='red', label='dhead', marker='x', linestyle='-')
+        else:
+            axes[0].plot(tail[i,0], tail[i,1], color='blue', marker='o', linestyle='-')
+            axes[0].plot(head[i,0], head[i,1], color='red', marker='o', linestyle='-')
+            axes[0].plot(dtail[i,0], dtail[i,1], color='blue', marker='x', linestyle='-')
+            axes[0].plot(dhead[i,0], dhead[i,1], color='red', marker='x', linestyle='-')
+        axes[0].plot([tail[i,0], head[i,0]], [tail[i, 1], head[i,1]], 'k--')
+        axes[0].plot([dtail[i,0], dhead[i,0]], [dtail[i, 1], dhead[i,1]], 'k--')
+    axes[0].vlines([target,], -2, 4, label='target')
+
+    grid_spacing = torch.tensor([0.5, 0.5, 0.5])
+    raster = tg.Raster(velocity, grid_spacing, pdims=(1,2))
+    ttail = dtime
+    thead = ttail + raster._time_diff(dtail, dhead)
+
+    for i in range(tail.size(0)):
+        if i == 0:
+            axes[1].plot(time, tail[i,1], color='blue', label='tail', marker='o', linestyle='-')
+            axes[1].plot(time, head[i,1], color='red', label='head', marker='o', linestyle='-')
+            axes[1].plot(ttail[i], dtail[i,1], color='blue', label='dtail', marker='x', linestyle='-')
+            axes[1].plot(thead[i], dhead[i,1], color='red', label='dhead', marker='x', linestyle='-')
+        else:
+            axes[1].plot(time, tail[i,1], color='blue', marker='o', linestyle='-')
+            axes[1].plot(time, head[i,1], color='red', marker='o', linestyle='-')
+            axes[1].plot(ttail[i], dtail[i,1], color='blue', marker='x', linestyle='-')
+            axes[1].plot(thead[i], dhead[i,1], color='red', marker='x', linestyle='-')
+        axes[1].plot([time, time], [tail[i, 1], head[i,1]], 'k--')
+        axes[1].plot([ttail[i], thead[i]], [dtail[i, 1], dhead[i,1]], 'k--')
+    axes[1].vlines([time,], -2, 4, label='initial time')
+
+    # Labels and legend
+    axes[0].set_xlabel("X-axis")
+    axes[0].set_ylabel("Y-axis")
+    axes[0].set_title("Tail, Head, before and after drifting")
+    axes[0].legend()
+    axes[0].grid(True)
+
+    axes[1].set_xlabel("Time")
+    axes[1].set_ylabel("Y-axis")
+    axes[1].set_title("Tail, Head, before and after driting")
+    axes[1].legend()
+    axes[1].grid(True)
+
+    # Show the plot
+    plt.savefig('drifted_tailhead.png')
 
 def main():
-    print('-------- test_compute_qeff ---------')
+    # print('-------- test_compute_qeff ---------')
     test_compute_qeff_raster_steps()
 
-    print('-------- test_transform ---------')
+    # print('-------- test_transform ---------')
     test_transform()
+
+    test_time_diff()
+
+    test_drift_raster_positions()
 
 if __name__ == '__main__':
     try:

--- a/tests/effq/test_raster_steps.py
+++ b/tests/effq/test_raster_steps.py
@@ -51,6 +51,14 @@ def test_transform(level=None):
     p = raster._transform(points, time)
     assert p.equal(torch.tensor([3, 2, 5]).view(1,3)), f'points after transformation is {p}.'
 
+    points = torch.tensor([3,4,5]).view(1,3)
+    time = torch.tensor([2])
+    pdims = (0, 2)
+    tdim = -1
+    raster = tg.Raster(velocity=0.16, grid_spacing=(1,1,1), pdims=pdims, tdim=tdim, nsigma=3.0)
+    p = raster._transform(points, time)
+    assert p.equal(torch.tensor([3, 5, 2]).view(1,3)), f'points after transformation is {p}.'
+
 def test_time_diff():
     """Test the _time_diff method.
         Test _time_diff with head as None."""

--- a/tests/effq/test_raster_steps.py
+++ b/tests/effq/test_raster_steps.py
@@ -5,8 +5,10 @@ import torch
 import logging
 import tred.graph as tg
 
+logger = logging.getLogger('tred/tests/effq/test_raster_steps.py')
+
 def test_compute_qeff_raster_steps(level=None):
-    local_logger = logging.getLogger('test_eval_qeff_raster_steps')
+    local_logger = logger.getChild('test_eval_qeff_raster_steps')
     if level:
         local_logger.setLevel(level)
 
@@ -26,10 +28,35 @@ def test_compute_qeff_raster_steps(level=None):
     assert q_sum > 0, "Raster steps computed integral should be positive"
     assert np.isclose(q_sum, qint, rtol=1E-5), f'Raster steps computed integral does not match predefined value {qint}.'
 
+def test_transform(level=None):
+    local_logger = logger.getChild('test_transform')
+    if level:
+        local_logger.setLevel(level)
+    local_logger.debug('Testing transform by predefined values')
+
+    points = torch.tensor([3,4,5]).view(1,3)
+    time = torch.tensor([2])
+    pdims = (1, 2)
+    tdim = 1
+    raster = tg.Raster(velocity=0.16, grid_spacing=(1,1,1), pdims=pdims, tdim=tdim, nsigma=3.0)
+    p = raster._transform(points, time)
+    assert p.equal( torch.tensor([4, 2, 5]).view(1,3) ),  f'points after transformation is {p}.'
+
+    points = torch.tensor([3,4,5]).view(1,3)
+    time = torch.tensor([2])
+    pdims = (0, 2)
+    tdim = 1
+    raster = tg.Raster(velocity=0.16, grid_spacing=(1,1,1), pdims=pdims, tdim=tdim, nsigma=3.0)
+    p = raster._transform(points, time)
+    assert p.equal(torch.tensor([3, 2, 5]).view(1,3)), f'points after transformation is {p}.'
+
+
 def main():
     print('-------- test_compute_qeff ---------')
     test_compute_qeff_raster_steps()
 
+    print('-------- test_transform ---------')
+    test_transform()
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
Defined a few test and fixed several bugs.

- Post-drift position components are now correctly handled. It is transformed to the desired axis in method `_transform`. This is verified in `test_raster_steps.py`.
- Post-drift time for both head and tail is now correctly defined as (tail - head) / velocity + time of tail at anodes. This relationship is illustrated in the plot generated by `test_raster_steps.py`. 
  In coordinate space, the steps stop at the target plane. In the time domain, the tail and head share a common time of creation but have different arrival times at the target plane. The point farther from the plane has a larger post-drift time, as shown in the generated figure.
- Diffusion widths are now properly transformed by swapping components and converting to a time series along the drift direction.
- Effective charges are now calculated. The integral passes the unit test in `test_raster_steps.py`.

