### PR TITLE
Alternative chunkify2

### DIFF
--- a/src/tred/graph.py
+++ b/src/tred/graph.py
@@ -29,7 +29,7 @@ from .raster.depos import binned as raster_depos
 from .raster.steps import compute_qeff
 
 from .types import index_dtype
-from .sparse import chunkify
+from .sparse import chunkify, chunkify2
 from .chunking import accumulate
 from .convo import interlaced
 
@@ -165,7 +165,7 @@ class Drifter(nn.Module):
         Parameters:
             - tail (torch.Tensor): Tensor representing tail positions, either 1D (`(npt,)`) or 2D (`(npt, vdim)`).
             - head (torch.Tensor): Tensor representing head positions, either 1D (`(npt,)`) or 2D (`(npt, vdim)`).
-            - velocity (float): Determines the direction of drift. Positive values prioritize larger `tail[:, vaxis]`, 
+            - velocity (float): Determines the direction of drift. Positive values prioritize larger `tail[:, vaxis]`,
                             while negative values prioritize smaller ones.
             - vaxis (int): The index of the axis along which the positions are compared.
 
@@ -327,7 +327,7 @@ class ChunkSum(nn.Module):
         Return a new block chunked to given shape and with overlaps summed.
         '''
         # fixme: May wish to put each in its own module if dynamic rebatching helps.
-        return accumulate(chunkify(block, self.chunk_shape))
+        return accumulate(chunkify2(block, self.chunk_shape))
 
 
 class LacedConvo(nn.Module):
@@ -348,7 +348,7 @@ class LacedConvo(nn.Module):
         # fixme: allow for response to be pre-FFT'ed
         return interlaced(signal, response, self.lacing, self._taxis)
 
-        
+
 class Charge(nn.Module):
     def __init__(self, drifter, raster, chunksum):
         super().__init__()

--- a/src/tred/sparse.py
+++ b/src/tred/sparse.py
@@ -17,6 +17,9 @@ from .util import to_tensor, to_tuple
 from .blocking import Block
 from .types import IntTensor, Shape, Tensor
 
+offset_dtype = torch.int64
+MAX_OFFSET = torch.iinfo(offset_dtype).max
+
 # fixme: Does this REALLY deserve to be a class?
 class SGrid:
     '''
@@ -163,6 +166,42 @@ def chunkify(block: Block, shape: IntTensor) -> Block:
     fill_envelope(envelope, block)
     return reshape_envelope(envelope, sgrid.spacing)
 
+def flat_index(ten, stride):
+    if len(ten.shape) !=2:
+        raise ValueError(f'sparse.flat_index() ten must be 2D tensor, but {len(ten.shape)} is given.')
+    if ten.dtype != offset_dtype:
+        raise ValueError(f'sparse.flat_index() ten must be in {offset_dtype}, but {ten.dtype} is given.')
+    if stride.dtype != stride.dtype != offset_dtype:
+        raise ValueError(f'sparse.flat_index() stride must be in {offset_dtype}, but {stride.dtype} is given.')
+    if ten.size(1) != stride.numel():
+        raise ValueError(f'Number of components in ten must match stride. stride length is {stride.numel()} while n components of ten is {ten.size(1)}')
+
+    return torch.sum(ten * stride[None,...], dim=1)
+
+def unflat_index(index, stride):
+    if index.dim() != 1:
+        raise ValueError(f'sparse.unflat_index() index must be 1D tensor, but {index.dim()}D is given.')
+    if index.dtype != torch.int32 and index.dtype != torch.int64:
+        raise ValueError(f'sparse.unflat_index() index must be in int32 or int64, but {index.dtype} is given.')
+    if stride.dtype != torch.int32 and stride.dtype != torch.int64:
+        raise ValueError(f'sparse.unflat_index() stride must be in int32 or int64, but {stride.dtype} is given.')
+
+    coord = []
+    rem = index
+    for s in stride:
+        coord.append(rem // s)
+        rem = rem % s
+    return torch.stack(coord, dim=1)
+
+def calculate_strides(shape: tuple|list|Tensor):
+    if not isinstance(shape, Tensor):
+        shape = torch.tensor(shape, dtype=offset_dtype)
+    if shape.ndim != 1:
+        raise ValueError(f"sparse.calculate_strides must be in 1D, but {shape.ndim} is given")
+    strides = [1,]
+    for s in torch.flip(shape, dims=(0,)):
+        strides.append(strides[-1] * s)
+    return strides[::-1]
 
 
 def chunkify2(block: Block, shape: IntTensor) -> Block:
@@ -173,51 +212,61 @@ def chunkify2(block: Block, shape: IntTensor) -> Block:
     sgrid = SGrid(shape)
     if not isinstance(block, Block):
         raise TypeError(f'sparse.chunkify2() block must be Block got {type(block)}')
+    envelope = sgrid.envelope(block)
 
-    # Find the minimum bin span that contains the block.
-    # Find the location of the bin containing the lowest point.
-    minpts = sgrid.gpoint(sgrid.spoint(block.location))
-    maxpts = sgrid.gpoint(sgrid.spoint(block.location+block.shape-1)+1)
-    shapes = maxpts - minpts
-    maxshape = torch.max(shapes, dim=0).values
-
-    # location of block inside the envelope.
-    offset = block.location
-    # if not torch.all(offset >= 0):
-    #     raise ValueError(f'fill_envelope negative locations of block {block.shape} in envelope {maxshape}')
+    minpts = envelope.location
 
     inner = block.shape
-    outer = maxshape
+    outer = envelope.shape
     nbatches = block.nbatches
-
-    locs = offset
-
+    locs = block.location - minpts
     cshape = sgrid.spacing.to(locs.device)
-
     ndim = int(inner.numel())
 
-    local_grid = torch.cartesian_prod(*[torch.arange(sz, device=locs.device) for sz in inner])  # [prod(inner), ndim]
+    ldevice = block.location.device
+    ddevice = block.data.device
 
+    # location of block inside the envelope.
+    outer_strides = torch.tensor(calculate_strides(outer), device=ldevice)
+    inner_strides = torch.tensor(calculate_strides(inner), device=ldevice)
+    chunk_strides = torch.tensor(calculate_strides(cshape), device=ldevice)
+    ind_strides = torch.tensor(calculate_strides(outer // cshape), device=ldevice)
+
+    if torch.any(outer % cshape):
+        raise ValueError("chunk shape must be dividable by SGrid.sgrid")
+
+    local_grid = torch.cartesian_prod(*[torch.arange(sz, device=ldevice) for sz in inner])  # [prod(inner), ndim]
+
+    # flat according to outer // cshape
     tile_coords  = (locs[:, None, :] + local_grid[None, :, :]) // cshape     # [nbatches, prod(inner), ndim]
+    tile_coords = flat_index(tile_coords.view(-1, ndim), ind_strides[1:]) # [nbatches * prod(inner),]
+    tile_coords = tile_coords.view(nbatches, local_grid.size(0))
+    bidx = torch.arange(0, nbatches*ind_strides[0]-1, ind_strides[0], dtype=offset_dtype, device=ldevice) # (nbatches,)
+    tild_idx = (bidx[:,None] + tile_coords).view(-1) # (nbatches * prod(inner))
+
+    tile_keys, reverse_indices = torch.unique(tild_idx, return_inverse=True, sorted=True)
+
+    locs_new = unflat_index(tile_keys, ind_strides)
+    locs_new[:,1:] = locs_new[:,1:] * cshape[None,:] 
+    _, reverse_bidx = torch.unique(locs_new[:,0], sorted=True, return_inverse=True)
+    locs_new = locs_new[:,1:] + minpts[reverse_bidx]
+
+    # flat according to cshape
     local_offsets = (locs[:, None, :] + local_grid[None, :, :]) % cshape     # [nbatches, prod(inner), ndim]
+    local_offsets = local_offsets.view(-1, ndim)
+    local_offsets = flat_index(local_offsets, chunk_strides[1:]) # [nbatches * prod(inner),]
 
-    bidx = torch.arange(nbatches).view(nbatches, 1, 1).expand(-1, local_grid.size(0), 1).to(locs.device)  # [nbatches, prod(inner), 1]
-
-    batch_tile_combo = torch.cat([bidx, tile_coords], dim=-1).reshape(-1, ndim + 1)
-    tile_keys, reverse_indices = torch.unique(batch_tile_combo, return_inverse=True, dim=0)
-
-    locs_new = tile_keys[:, 1:] * cshape[None,:]  # [num_tiles, ndim]
-
-    data = torch.zeros((tile_keys.size(0),) + tuple(cshape.tolist()), dtype=block.data.dtype, device=block.data.device)
+    # FIXME: CUDA-CPU SYNC
+    data = torch.zeros((tile_keys.size(0),) + tuple(cshape.tolist()), dtype=block.data.dtype, device=ddevice)
 
     tile_indices = reverse_indices.view(-1)                     # [nbatches * prod(inner)]
-    local_offsets = local_offsets.view(nbatches * local_grid.size(0), ndim)
-    values = block.data.flatten()                                        # [nbatches * prod(inner)]
+    values = block.data.flatten()                               # [nbatches * prod(inner)]
 
-    index = [tile_indices] + [local_offsets[:, d] for d in range(ndim)]
-    data[tuple(index)] = values
+    index = [tile_indices, local_offsets]
+    data.view(-1, chunk_strides[0])[tuple(index)] = values
 
     return Block(location=locs_new, data=data)
+
 
 def index_chunks(sgrid: SGrid, chunk: Block) -> Block:
     '''

--- a/tests/README.org
+++ b/tests/README.org
@@ -19,3 +19,4 @@ Tests are
   : uv run python test_blocking.py
   : uv run python test_indexing.py
   : uv run python test_sparse.py
+  : uv run pytest --log-cli-level=INFO test_sparse.py

--- a/tests/sparse/perf_chunking.py
+++ b/tests/sparse/perf_chunking.py
@@ -1,4 +1,5 @@
 from tred.chunking import accumulate
+from tred.sparse import chunkify, chunkify2
 from tred.blocking import Block
 
 import torch
@@ -6,6 +7,67 @@ import torch.utils.benchmark as benchmark
 import time
 
 from torch.distributions import Poisson, Exponential
+
+def benchmark_chunkify(fchunkify, outpickle, devices):
+    torch.cuda.reset_peak_memory_stats()
+    # prepare for test data
+    device = devices['data']
+    ldevice = devices['location']
+
+    nbatches = 2_000
+    shape = (30, 30, 30)
+    location = torch.tensor([-1, -1, -1, 0, 0, 0]).repeat(nbatches//2).view(nbatches, 3).to(ldevice)
+    data = torch.ones((nbatches, *shape), dtype=torch.int64, device=device)
+    cshape = (25, 25, 25)
+    cshape = torch.tensor(cshape, device=ldevice)
+
+    # Start recording memory snapshot history, initialized with a buffer
+    # capacity of 100,000 memory events, via the `max_entries` field.
+    MAX_NUM_OF_MEM_EVENTS_PER_SNAPSHOT = 100_000
+    torch.cuda.memory._record_memory_history(
+        max_entries=MAX_NUM_OF_MEM_EVENTS_PER_SNAPSHOT
+    )
+
+    # Run your PyTorch Model.
+    # At any point in time, save a snapshot to file for later.
+    with torch.no_grad():
+        o = fchunkify(Block(location=location, data=data), shape=cshape)
+    # In this sample, we save the snapshot after running code above
+    #   - Save as many snapshots as you'd like.
+    #   - Snapshots will save last `max_entries` number of memory events
+    #     (100,000 in this example).
+    try:
+        torch.cuda.memory._dump_snapshot(outpickle)
+    except Exception as e:
+        logger.error(f"Failed to capture memory snapshot {e}")
+
+    peak_mem = torch.cuda.max_memory_allocated()
+    # Stop recording memory snapshot history.
+    torch.cuda.memory._record_memory_history(enabled=None)
+    print('Maximum cuda memory allocated', peak_mem/1024**2, 'MB')
+
+    # record time
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+
+    start_event.record()
+    # Code to benchmark
+    with torch.no_grad():
+        fchunkify(Block(location=location, data=data), shape=cshape)
+    end_event.record()
+    torch.cuda.synchronize()
+    elapsed_time_ms = start_event.elapsed_time(end_event)
+    print(f'Elpased {elapsed_time_ms} ms on GPU')
+
+    location_cpu = location.to('cpu')
+    data_cpu = data.to('cpu')
+    start_time = time.time()
+    # Code to benchmark
+    with torch.no_grad():
+        chunkify(Block(location=location_cpu, data=data_cpu), shape=shape)
+    end_time = time.time()
+    elapsed_time_ms = 1E3*(end_time - start_time)
+    print(f'Elpased {elapsed_time_ms} ms on CPU')
 
 def benchmark_accumulate():
     # prepare for test data
@@ -81,7 +143,12 @@ def benchmark_accumulate():
     print(f'Elpased {elapsed_time_ms} ms on CPU')
 
 def main():
+    print('accumulate')
     benchmark_accumulate()
+    print('chunkify')
+    benchmark_chunkify(chunkify, 'chunkify.pickle', devices={'data' : 'cuda', 'location' : 'cuda'})
+    print('chunkify2')
+    benchmark_chunkify(chunkify2, 'chunkify2.pickle', devices={'data' : 'cuda', 'location' : 'cuda'})
 
 
 if __name__ == '__main__':

--- a/tests/sparse/perf_chunking.py
+++ b/tests/sparse/perf_chunking.py
@@ -30,8 +30,11 @@ def benchmark_chunkify(fchunkify, outpickle, devices):
 
     # Run your PyTorch Model.
     # At any point in time, save a snapshot to file for later.
+    nel = 1
     with torch.no_grad():
         o = fchunkify(Block(location=location, data=data), shape=cshape)
+        nel = o.data.numel()
+        o = None
     # In this sample, we save the snapshot after running code above
     #   - Save as many snapshots as you'd like.
     #   - Snapshots will save last `max_entries` number of memory events
@@ -45,6 +48,7 @@ def benchmark_chunkify(fchunkify, outpickle, devices):
     # Stop recording memory snapshot history.
     torch.cuda.memory._record_memory_history(enabled=None)
     print('Maximum cuda memory allocated', peak_mem/1024**2, 'MB')
+    print('Allocated for output', nel*8/1024**2, 'MB')
 
     # record time
     start_event = torch.cuda.Event(enable_timing=True)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -146,7 +146,7 @@ def test_sparse_funcs_multichunk():
     assert torch.equal(c0, d0), f'{c0}, {d0}'
 
 
-def test_sparse_chunkify():
+def test_sparse2d_chunkify():
     '''
     Test all in one chunkify() function
     '''
@@ -215,3 +215,4 @@ def test_sparse_chunkify():
     # b_index = ic_index[s_index]
     b_index = ic_index[s_index.tolist()]
     assert torch.all(b_index == torch.arange(chunk.nbatches)), f'{b_index}'
+


### PR DESCRIPTION
An alternative `chunkify2` for chunking blocks as proposed in #40.
- Added a few tests in `tests/sparse/test_sparse.py`.
- Change default chunking method to `chunkify2`.