### PR TITLE
Add code examination docs: bugs, efficiency, memory, algorithms

### DIFF
--- a/docs/examinations/00_overview.md
+++ b/docs/examinations/00_overview.md
@@ -1,0 +1,187 @@
+# TRED Codebase Overview
+
+> Read-only examination.  No source files were modified.
+> Cross-references: [01_algorithms.md](01_algorithms.md) [02_bugs.md](02_bugs.md) [03_gpu_efficiency.md](03_gpu_efficiency.md) [04_memory.md](04_memory.md) [99_open_questions.md](99_open_questions.md)
+
+---
+
+## What TRED Does
+
+TRED is a three-dimensional detector-response simulation for liquid-argon
+time-projection chambers (LArTPCs) with pixel readout.  It targets NuMI
+Near Detector / ND-LAr geometry.  The code is pure Python on top of PyTorch
+and is designed to run on CPU or GPU (tested on CUDA).
+
+Given a set of ionising particle **steps** (or point **depos**) from a
+Geant4-level tracker, TRED outputs **waveforms** (digitised current vs. time)
+on every pixel that triggered, equivalent to what the real detector produces.
+
+---
+
+## Repository Layout
+
+```
+tred/
+├── src/tred/               # library
+│   ├── graph.py            # nn.Module wrappers for pipeline stages
+│   ├── blocking.py         # Block data structure (batch of rectangular volumes)
+│   ├── sparse.py           # Block-Sparse Binned (BSB) operations & SGrid
+│   ├── chunking.py         # accumulate(), content(), location() for BSB chunks
+│   ├── partitioning.py     # deinterlace / de-interlace-pairs for convolution
+│   ├── indexing.py         # crop_batched helper
+│   ├── bsb.py              # (thin class wrapper around sparse.py functions)
+│   ├── drift.py            # drift / diffuse / absorb physics
+│   ├── recombination.py    # Birks / Modified-Box recombination models
+│   ├── raster/
+│   │   ├── depos.py        # Gaussian charge boxes for point depos
+│   │   └── steps.py        # Gaussian-weighted line integrals for steps (GL)
+│   ├── response.py         # Load & reformat ND-LAr field response tensor
+│   ├── convo.py            # Interlaced FFT-based convolution
+│   ├── readout.py          # Discriminator / ADC / CSA model
+│   ├── loaders.py          # NpzFile, HdfFile, StepLoader datasets
+│   ├── io_nd.py            # ND-specific datasets, samplers, geometry parser
+│   ├── io.py               # write_npz
+│   ├── util.py             # to_tensor, to_tuple, iter_tensor_chunks, ...
+│   ├── units.py            # physical unit constants
+│   ├── types.py            # index_dtype, type aliases
+│   ├── cli.py              # Click CLI (plots, fullsim commands)
+│   └── plots/
+│       └── graph_effq.py   # fullsim end-to-end pipeline (runit / fullsim)
+├── docs/
+│   ├── concepts.org        # Block-Sparse Binned concepts and terminology
+│   ├── internals.org       # Developer notes on grids, sparse data, indexing
+│   ├── convo.org           # Convolution design notes
+│   └── examinations/       # ← this directory
+└── tests/                  # pytest suite
+```
+
+---
+
+## Full-Simulation Pipeline (`fullsim`)
+
+Entry point: `cli.py:fullsim` → `plots/graph_effq.py:fullsim` →
+`plots/graph_effq.py:runit`.
+
+### Stage-by-stage data flow
+
+```
+Input HDF5 file
+    │
+    ▼
+[IO / loaders]
+StepLoader / steps_from_ndh5             loaders.py, io_nd.py
+    │  features: (N_steps, 11) float32    (dE, dEdx, x0,y0,z0, x1,y1,z1, t0,t1,...)
+    │  labels:   (N_steps, ...) int       (event id, tpc id, ...)
+    ▼
+[Recombination]  recombination.py
+birks(dE, dEdx, efield, rho, ...)   → charge (N_steps,) float32
+    │
+    ▼
+[Drift]  drift.py / graph.py:Drifter
+drift(locs, velocity, diffusion, lifetime, target, ...)
+    → dsigma (N_steps, 3)   post-drift Gaussian sigma
+    → dtime  (N_steps,)     time at response plane
+    → dcharge(N_steps,)     absorbed charge
+    → dtail  (N_steps, 3)   position near anode
+    → dhead  (N_steps, 3)   position far from anode
+    │
+    ▼
+[Raster]  raster/steps.py / graph.py:Raster
+compute_qeff(grid_spacing, X0, X1, Sigma, Q, n_sigma, npoints, method)
+    → Block(location: (N_steps, 3) int, data: (N_steps, Sx, Sy, St) float64)
+    Each "charge box" is a dense 3-D tensor giving effective electron
+    counts on grid voxels near the step, computed by Gauss–Legendre
+    quadrature of the 3D anisotropic Gaussian.
+    │
+    ▼
+[ChunkSum — charge]  sparse.py / chunking.py / graph.py:ChunkSum
+chunkify → accumulate
+    Merges charge boxes onto a coarser super-grid (chunk_shape voxels).
+    Returns a Block of non-overlapping chunks ready for convolution.
+    │  signal Block: (N_chunks, Cx, Cy, Ct) float
+    ▼
+[LacedConvo]  convo.py / graph.py:LacedConvo
+interlaced_symm_v2(signal, response, lacing=[10,10,1])
+    De-interlaces signal and response by impact position (lacing factor),
+    FFT-convolves each pair, exploits mirror symmetry to halve the FFT
+    count, accumulates currents.
+    Returns Block(location, data: (N_chunks, Cx', Cy', Ct')) float
+    │
+    ▼
+[ChunkSum — current]  chunking.py / graph.py:ChunkSum
+    Sums overlapping current chunks.
+    │
+    ▼
+[ChunkSum — readout grouping]
+    Re-groups to (1,1,120) pixel×tick blocks for readout.
+    │
+    ▼
+[concatenate_waveforms]  plots/graph_effq.py
+    Sparse currents assembled into dense waveform array per pixel.
+    │
+    ▼
+[Readout]  readout.py:nd_readout
+    Cumulative-sum discriminator / ADC hold / CSA reset model.
+    Returns list of (pixel, time, hold_time, start_time, charge) hits.
+    │
+    ▼
+Output NPZ file  (io.py:write_npz)
+```
+
+### Loop structure
+
+The full pipeline is batched at two levels:
+1. **TPC loop** — one pass per TPC module in the geometry (~8 for 2×2).
+2. **Batch loop** — within each TPC, steps are fed in batches of
+   `batch_scheme[0]` (default 4096×8 = 32768) steps per raster call, then
+   further sub-batched at `batch_scheme[1]` (default 50 chunks) per
+   convolution call.
+
+---
+
+## Key Data Types
+
+| Name | Where | Shape (example) | Dtype | Description |
+|------|--------|-----------------|-------|-------------|
+| `Block` | `blocking.py` | location (N,3), data (N,Sx,Sy,St) | int32/float32 | Batched sparse volumes |
+| charge box | `raster/steps.py` | (N_steps, Sx, Sy, St) | float64 | Per-step Gaussian integral |
+| signal Block | after ChunkSum | (N_chunks, Cx,Cy,Ct) | float32 | Coarse-grid charge |
+| response tensor | `response.py` | (90,90,6400) | float32 | Pixel field response |
+| current Block | after convo | (N_chunks, Cx',Cy',Ct') | float32 | Induced currents |
+| waveform | `concatenate_waveforms` | (N_pixels, Nt) | float32 | Dense pixel waveforms |
+
+---
+
+## Device Strategy
+
+- All `nn.Module` objects (Drifter, Raster, ChunkSum, LacedConvo) are
+  `.to(device)` at construction time.
+- Input data is loaded on CPU and moved with `[f.to(device) for f in features]`
+  at the start of each batch — this is a single transfer per batch.
+- The response tensor is moved to device once per TPC invocation:
+  `response.to(device=device)`.
+- The `raster/steps.py` module uses `float_dtype = torch.float64` throughout.
+  On CUDA GPUs without native FP64 (consumer cards), this imposes a large
+  performance penalty.  See [03_gpu_efficiency.md](03_gpu_efficiency.md#fp64).
+
+---
+
+## Existing Profiling Data
+
+The repo root contains `itpc_timing_summary.{csv,json}` and
+`pie_chart_{all,noconvo}.png`, suggesting prior per-stage timing on the
+full pipeline.  These are a useful baseline before making optimisations.
+
+---
+
+## Design Documents
+
+The existing `docs/` org-mode files are valuable reading alongside this
+examination:
+
+- `docs/concepts.org` — Block-Sparse Binned (BSB) terminology, super-grid, bins.
+- `docs/internals.org` — grids, voxels, sparse data, key accumulation
+  problem, scatter/gather patterns, vmap, jagged tensors.
+- `docs/convo.org` — convolution design rationale.
+- `docs/response.org` — response format.
+- `docs/data.org` — data formats.

--- a/docs/examinations/01_algorithms.md
+++ b/docs/examinations/01_algorithms.md
@@ -1,0 +1,325 @@
+# TRED Algorithm Explanations
+
+> Read-only examination. No source files were modified.
+> See also [00_overview.md](00_overview.md) for data-flow context.
+
+---
+
+## 1. Recombination (`recombination.py`)
+
+### What it does
+Converts energy deposition (dE in MeV) and stopping power (dE/dx in MeV/cm)
+into an expected number of ionisation electrons surviving recombination.
+
+Two models are implemented:
+
+**Birks model** (`recombination.py:13`):
+```
+R = A / (1 + dEdx * k / (E * rho))
+Q = R * dE / Wi
+```
+
+**Modified Box model** (`recombination.py:37`):
+```
+R = ln(A + B*dEdx/(E*rho)) / (B*dEdx/(E*rho))
+Q = R * dE / Wi
+```
+
+Both are fully vectorised over (N_steps,). No Python loops. No GPU sync.
+Typical output dtype: float32.
+
+### Key tensors
+| Tensor | Shape | Dtype |
+|--------|-------|-------|
+| dE, dEdx | (N_steps,) | float32 |
+| charge Q out | (N_steps,) | float32 |
+
+### Cost
+Low: two element-wise operations over N_steps. Memory: O(N_steps).
+
+---
+
+## 2. Drift (`drift.py`)
+
+### What it does
+Models three physical processes for each step / depo:
+1. **Transport** (`drift.py:20`): computes drift time `dt = (target − loc) / v`
+   along the drift axis (default x, `vaxis=0`).
+2. **Diffusion** (`drift.py:32`): computes post-drift Gaussian sigma via
+   `sigma = sqrt(2*D*dt + sigma0^2)` (quadrature addition of longitudinal and
+   transverse diffusion).  Separate diffusion coefficients are supported per
+   dimension.
+3. **Absorption** (`drift.py:82`): applies electron lifetime attenuation
+   `Q_out = Q_in * exp(-dt / lifetime)`.  With `fluctuate=True` applies a
+   Binomial fluctuation on top.
+
+All three operations are vectorised over (N_steps,).  The `Drifter` nn.Module
+(`graph.py:67`) wraps these and adds a swap to ensure the "tail" is always
+the point closer to the anode.
+
+Optional time-shift correction `drtoa` converts anode-plane drift time to
+response-plane drift time.
+
+### Key tensors
+| Tensor | Shape | Dtype |
+|--------|-------|-------|
+| locs in/out | (N_steps,) or (N_steps, vdim) | float32 |
+| times in/out | (N_steps,) | float32 |
+| sigma out | (N_steps, vdim) | float32 |
+| charge out | (N_steps,) | int32 → float32 |
+
+### Cost
+Low: all element-wise or broadcast operations. Memory: O(N_steps × vdim).
+Notable: `locs.detach().clone()` copies the position tensor every call
+(`drift.py:154`). See [04_memory.md](04_memory.md#drift-clone).
+
+---
+
+## 3. Raster — Depos (`raster/depos.py`)
+
+### What it does
+For point-like depos, computes the effective charge on each grid voxel by
+integrating the 3-D Gaussian distribution over each voxel.
+
+The N-D version (`binned_nd`, `raster/depos.py:128`) works as follows:
+
+1. Compute per-depo, per-dimension half-span `n_half`:
+   how many grid points are needed to cover ±nsigma×sigma.  **Critically,
+   the maximum over all depos is taken**, creating a universal box shape.
+2. Build the `grid0` lower corner for each depo.
+3. Loop over spatial dimensions (Python `for` loop, `raster/depos.py:193`).
+   For each dimension:
+   a. Construct relative grid point indices via `torch.linspace`.
+   b. Convert to absolute coordinates.
+   c. Compute `erf` values at bin edges.
+   d. Compute bin integrals as half the difference of adjacent erfs.
+4. Form the N-D charge box as the outer product of per-dimension integrals via
+   `torch.einsum` (for N=2 or N=3).
+5. Multiply by Q.
+
+**Output:** `(qeff, grid0)` where `qeff` has shape `(N_depos, 2*n_half[0]+1,
+2*n_half[1]+1, 2*n_half[2]+1)` and `grid0` has shape `(N_depos, vdim)`.
+
+### Key property: universal (worst-case) box shape
+Because all depos are padded to the same box shape (maximum sigma depo),
+depos with small diffusion waste most of their allocated voxels.  This is
+a significant memory amplification when sigma varies widely. See
+[04_memory.md](04_memory.md#universal-box).
+
+---
+
+## 4. Raster — Steps (`raster/steps.py`)
+
+### What it does
+For line-segment steps, computes the charge distribution by integrating the
+**anisotropic 3-D Gaussian smeared along a line segment** over each grid
+voxel.  This is substantially more complex than point depos.
+
+The key function is `compute_qeff` which calls `compute_charge_box` then
+one of two evaluation methods:
+
+**Method `gauss_legendre`** (default):
+Uses Gauss–Legendre quadrature to numerically integrate the charge density
+`qline_diff3D` (`steps.py:190`) at GL nodes within each grid voxel, then
+sums the weighted values.  The analytical integrand is:
+
+```
+q(x,y,z) = Q / (4π Δ) * exp(-sy²(x*dz01 + ...) / (2Δ²))
+          * exp(...) * exp(...) * [erf(·) - erf(·)]  / (sqrt(2) Δ sx sy sz)
+```
+where `Δ = sqrt(sy²sz²*dx01² + sx²sy²*dz01² + sx²sz²*dy01²)` (the
+denominator encoding the line-spread geometry).  This is computed as a
+TorchScript function (`qline_diff3D_script`, `steps.py:216`) for JIT speed.
+
+The GL quadrature uses `npoints=(2,2,2)` by default (8 evaluation nodes per
+voxel), with weights pre-computed once via `create_wu_block`.
+
+**Short step fallback**: steps shorter than 5% of the sigma along any
+dimension are treated as point depos (`qpoint_diff3D`, `steps.py:279`).
+
+### Universal shape
+Same issue as depos: `reduce_to_universal` (`steps.py:112`) collapses all
+per-step box shapes to the per-batch maximum before allocating, so every
+step's charge box is padded to the worst-case size.
+See [04_memory.md](04_memory.md#universal-box).
+
+### Float64 usage
+The entire `steps.py` module uses `float_dtype = torch.float64` (line 11).
+The analytical integrand requires precision, but fp64 on consumer CUDA GPUs
+runs at 1/32× of fp32 throughput.
+See [03_gpu_efficiency.md](03_gpu_efficiency.md#fp64).
+
+---
+
+## 5. Block Data Structure (`blocking.py`)
+
+A `Block` is the central data container throughout TRED.  It holds:
+- `location`: (N_batches, vdim) int32 tensor — absolute grid-index of the
+  lower corner of each volume.
+- `data`: (N_batches, d1, d2, ..., dN) float tensor — values on the volume.
+
+All volumes in one Block share the same `shape` (d1,d2,...,dN), so a Block
+is essentially a dense batched tensor of rectangular volumes at arbitrary
+sparse locations.  This is the "Block Sparse Binned" representation described
+in `docs/concepts.org`.
+
+Key methods: `size()` (with CPU sync warning), `vdim`, `nbatches`.
+Helper: `concat_blocks(blocks)` — concatenates along the batch dimension.
+
+---
+
+## 6. Block-Sparse Accumulation (`sparse.py` / `chunking.py`)
+
+### The central problem
+After rastering, each step produces one charge box (a Block batch element)
+at an arbitrary grid location.  Many boxes overlap on the grid.  The goal
+is to **merge overlapping boxes** onto a coarser "chunk" grid, summing
+charges at common voxels.
+
+### chunkify (sparse.py:160)
+1. Create a `SGrid` with spacing = `chunk_shape`.
+2. Compute the smallest aligned "envelope" Block containing all input blocks.
+3. Call `fill_envelope`: expand the (possibly empty) envelope tensor and
+   write each input block into it at the correct offset using flat indexing
+   (`crop_batched`).
+4. Call `reshape_envelope`: view the envelope as a grid of chunks, return
+   a new Block where each batch element is one chunk.
+
+**Key limitation**: `fill_envelope` **assigns** (not accumulates) values into
+the envelope (`sparse.py:131`).  This means if two input blocks map to the
+same voxel in the envelope, the second silently overwrites the first.
+Whether this is safe depends on the invariant that `chunkify` is called with
+non-overlapping source blocks — see [02_bugs.md](02_bugs.md#fill-envelope).
+
+### accumulate (chunking.py:140)
+After chunkify produces a Block of chunks (some at identical locations):
+1. `torch.unique(loc, dim=0)` finds distinct chunk locations.
+2. `index_add_(0, inverse, data)` accumulates data from duplicate chunks
+   into a single output.
+3. Non-zero chunks (|val| > 1e-3) are retained.
+
+`index_add_` is a single parallel GPU operation — efficient.
+
+### Alternative: chunkify2 (sparse.py:207)
+A second, scatter-based implementation that does not build an explicit
+envelope.  Instead it computes flat tile indices for every element of every
+block and uses a two-step `scatter_add_ + index_add_` to accumulate directly.
+This avoids the large envelope allocation but has a CUDA-CPU sync hazard
+(`sparse.py:265`).  See [03_gpu_efficiency.md](03_gpu_efficiency.md#chunkify2-sync).
+
+### accumulate_nd_blocks_v1 / v2 (sparse.py:275 / 315)
+Two in-place variants that skip the envelope entirely and operate on
+the raw Block data tensor.  `_v1` has a Python for-loop over unique chunk
+indices (very slow; see [03_gpu_efficiency.md](03_gpu_efficiency.md#v1-loop)).
+`_v2` uses `scatter_add_` and is much better but has index-shape complexity
+bugs under certain configurations — see [02_bugs.md](02_bugs.md#v2-scatter).
+
+---
+
+## 7. Interlaced Convolution (`convo.py` / `partitioning.py`)
+
+### Motivation
+The ND-LAr pixel response tensor represents the induced current at a pixel
+for an electron landing at each of `nimperpix × nimperpix = 10×10 = 100`
+impact positions within the pixel pitch.  A direct convolution of the charge
+grid with the response must account for this sub-pixel structure.
+
+The approach is called "interlaced" convolution:
+- The charge grid has a fine spacing (1/10 pixel pitch).
+- The response tensor also lives on this fine grid but only has support at
+  every 10th point (the "lace" spacing = `[10, 10, 1]`).
+- For each (impact_x, impact_y) combination (50 pairs exploiting mirror
+  symmetry), extract the corresponding "lace" from both signal and response
+  and perform a standard FFT convolution.
+- Sum the 50 partial convolutions to get the total induced current.
+
+### interlaced_symm_v2 (convo.py:344) — current recommended version
+
+1. **DFT shape**: compute the padded size needed for linear (non-circular)
+   convolution: `c_shape = signal_size/lacing + response_size/lacing - 1`.
+2. **De-interlacing** (`partitioning.py:63`): for each of the
+   `nimperpix/2 = 5` symmetric pairs along the transverse axis, extract
+   signal and response laces via strided slicing.  Use the complex-number
+   trick: pack a pair `(lace_fwd, flip(lace_rev))` into real and imaginary
+   parts of a complex tensor so one FFT handles both.
+3. **FFT, multiply, accumulate**: pad to `o_shape`, `fftn`, multiply
+   `response_fft × signal_fft`, accumulate into `meas`.
+4. **iFFT and unpack**: `ifftn`, then `meas.real + flip(meas.imag)` unpacks
+   the symmetric pair trick.
+
+### Recomputing response FFT every call
+The line `torch.fft.fftn(res_[None,...], dim=dims)` (`convo.py:385`) is
+inside the per-lace loop AND called on every `forward()` invocation.  The
+response never changes between calls; pre-computing and caching its FFT
+would be a significant speedup.  See [03_gpu_efficiency.md](03_gpu_efficiency.md#fft-cache).
+
+---
+
+## 8. Readout (`readout.py`)
+
+### What it does
+Models the pixel electronics chain:
+1. Compute a cumulative sum of the induced current waveform (`Xacc = X.cumsum`).
+2. Iteratively find the first time tick where the accumulated charge exceeds
+   the pixel threshold (discriminator crossing).
+3. Record: crossing time, charge at ADC hold time (`hold_t = cross_t + adc_hold_delay`).
+4. Reset the accumulator at `hold_t + csa_reset_time`, advance the "start"
+   pointer to `hold_t + adc_down_time` to model dead time.
+5. Repeat until no more crossings.
+
+The threshold can be per-pixel (loaded from HDF5, shape (N_pixels,)).
+
+Output: flat list of (pixel_x, pixel_y, t_cross, t_hold, t_start) and
+corresponding charge.
+
+### Iteration on GPU
+The while-loop at `readout.py:67` iterates until `triggered.any() == False`.
+Each `triggered.any()` forces a CPU-GPU sync (`.any()` is a reduction that
+requires pulling a scalar back to the host).  The number of iterations equals
+the maximum number of ADC triggers any single pixel fires.  This can be
+many tens of iterations for high-occupancy events.
+See [03_gpu_efficiency.md](03_gpu_efficiency.md#readout-loop).
+
+---
+
+## 9. Response Loading (`response.py`)
+
+### What it does
+Loads the ND-LAr field response `.npy` file (shape `(45, 45, 6400)` — quarter
+of the full response), applies quadrant symmetry (`quadrant_copy`) to produce
+the full `(90, 90, 6400)` tensor, then reorders axes to make impact-position
+indexing contiguous for the laced convolution:
+
+```
+raw (45,45,6400) → full (90,90,6400)
+→ view (9, 10, 9, 10, 6400)   # npxl × nimp × npxl × nimp × Nt
+→ flip on dims (0,2)
+→ reshape (90, 90, 6400)
+→ .contiguous()
+```
+
+The `view + reshape + contiguous()` sequence creates a full physical copy of
+the 90×90×6400 response (≈ 207 MB at float32).  This lives on the GPU for
+the entire run.
+
+---
+
+## 10. IO and Loaders (`loaders.py`, `io_nd.py`)
+
+### StepLoader / steps_from_ndh5
+Reads steps from an HDF5 file as NumPy arrays via h5py, converts to
+`torch.tensor`.  Conversion uses `torch.tensor(np_array, dtype=..., requires_grad=False)`
+which always copies.  `torch.from_numpy` followed by `.to(dtype)` would be
+more memory-efficient for the in-place case.
+
+### NpzFile / HdfFile
+Both use `torch.tensor(data, dtype=..., requires_grad=False)` on every key
+access, meaning each item is copied on load.  The HDF5 loader stores an open
+file handle (`self._fp = h5py.File(path)`) but does not close it explicitly.
+
+### CustomNDLoader / batch samplers
+`io_nd.py` provides custom PyTorch DataLoader subclasses with three sampling
+strategies (sorted, eager, lazy).  `SortedLabelBatchSampler` sorts by event
+label to keep related steps in the same batch — this is useful to keep steps
+belonging to one physics event together, but it discards stochastic shuffling
+that might help GPU utilisation.

--- a/docs/examinations/02_bugs.md
+++ b/docs/examinations/02_bugs.md
@@ -1,0 +1,296 @@
+# TRED Potential Bugs
+
+> Read-only examination.  No source files were modified.
+> Severity tags: **likely** (probably wrong), **possible** (context-dependent),
+> **nit** (not a bug, but an easy-to-hit trap).
+> Each entry gives: location · summary · why it looks wrong · how to confirm · suggested fix direction.
+
+---
+
+## BUG-01 — `fill_envelope` overwrites instead of accumulating   {#fill-envelope}
+
+**Severity:** likely  
+**Location:** `src/tred/sparse.py:131`
+
+```python
+envelope.data.flatten()[inds] = block.data.flatten()
+```
+
+**Problem:**  
+This is an assignment (`=`), not an accumulation (`+=`).  If two input blocks
+map to the same voxel inside the envelope (i.e., `inds` contains duplicates),
+the second value silently clobbers the first with no error or warning.
+
+**Why this might be acceptable:**  
+`fill_envelope` is called from `chunkify` (`sparse.py:167`) with a single
+`block` argument at a time, not in a loop.  `chunkify` first builds the
+envelope from the full block's bounding box, then fills it once.  The danger
+arises if the *source block itself* has two batch elements mapping to the same
+envelope voxel, which can happen when charge boxes overlap (they often do for
+nearby steps).
+
+**How to confirm:**  
+Check whether `inds` returned by `indexing.crop_batched` can ever contain
+duplicate entries for a realistic set of overlapping charge boxes.  A quick
+diagnostic: compute `len(inds) > len(torch.unique(inds))` before the
+assignment.
+
+**Fix direction:**  
+Replace the assignment with:
+```python
+envelope.data.flatten().scatter_add_(0, inds, block.data.flatten())
+```
+or use `index_add_`.
+
+---
+
+## BUG-02 — `meas.real = …` assignment on a complex tensor   {#convo-real-assign}
+
+**Severity:** possible (version-dependent)  
+**Location:** `src/tred/convo.py:391`
+
+```python
+meas.real = meas.real + torch.flip(meas.imag, dims=flipdims)
+```
+
+**Problem:**  
+In PyTorch, `Tensor.real` on a complex tensor returns a *view* into the real
+part, and assigning to it via `=` rebinds the Python name `meas.real` to a
+new tensor rather than modifying the complex tensor in-place.  As a result
+the intended "add the flipped imaginary part into the real part" may silently
+be a no-op (or raise depending on PyTorch version).
+
+The function then returns `Block(data=meas.real, ...)`, which would return
+only the real part — so if the assignment is a no-op the imaginary
+contribution (encoding the "flipped symmetric lace") is lost, giving wrong
+induced-current values.
+
+**How to confirm:**  
+Run a 1-D or 2-D toy simulation with known symmetry, check the returned
+currents are non-zero on the symmetric side.  Alternatively inspect
+`meas.real` before and after line 391 to see whether it changes.
+
+**Fix direction:**  
+Use `torch.view_as_real`, operate on the view, then `torch.view_as_complex`,
+or simply:
+```python
+result = meas.real + torch.flip(meas.imag, dims=flipdims)
+return Block(data=result, location=super_location)
+```
+
+---
+
+## BUG-03 — Absolute threshold `1e-3` in `accumulate` drops valid charge   {#accumulate-threshold}
+
+**Severity:** possible  
+**Location:** `src/tred/chunking.py:157`
+
+```python
+indices = torch.where((torch.abs(summed) > 1e-3).any(dim=[i+1 for i in range(chunk.vdim)]))
+```
+
+**Problem:**  
+The code drops any chunk whose maximum absolute value is ≤ 1e-3.  This
+threshold is dimensionally meaningless: charge values are in units of
+electrons (typical ~ 10–10,000 e⁻), but induced current values after
+convolution can be in different units and can legitimately be much smaller
+than 1e-3 (e.g. if the response is in units of e⁻/tick and currents are
+fractional electrons per 50 ns tick, typical values are ~0.001–0.1).
+
+In the readout stage, chunks with very small currents can be real signal if
+the pixel is near threshold.  Dropping them will mis-model near-threshold
+behaviour.
+
+**How to confirm:**  
+Add a counter before and after the `indices` filter that prints the number
+of dropped chunks.  For a high-occupancy event, non-zero drops could indicate
+suppression of small-signal voxels.
+
+**Fix direction:**  
+Use a relative threshold (max|summed| / max|dat| > epsilon) or remove the
+filter entirely and let the readout threshold do the zero-suppression.
+
+---
+
+## BUG-04 — Integer truncation in `absorb` causes biased electron absorption   {#absorb-int}
+
+**Severity:** likely  
+**Location:** `src/tred/drift.py:96–102`
+
+```python
+charge = charge.to(dtype=torch.int32)      # line 96
+...
+return torch.where(dt>=0, charge * torch.exp(-dt / lifetime), charge)  # line 102
+```
+
+**Problem:**  
+`charge * torch.exp(-dt/lifetime)` computes a float, but `charge` is int32
+and PyTorch performs `where` with the dtype of the first truthy branch.
+For small drift times, `exp(-dt/lifetime) ≈ 0.9999...` and the result cast
+to int32 is truncated to the original integer (or in some PyTorch versions
+the multiply is promoted to float then `where` returns float — behaviour
+differs by version).
+
+More critically, when `fluctuate=False` (the default), the absorption
+`charge * exp(-dt/lifetime)` is the **mean** expected charge, not an integer.
+Truncating to int32 introduces a systematic downward bias of up to 1 electron
+per step, which accumulates across many steps.
+
+**How to confirm:**  
+Pass `charge = torch.tensor([1000], dtype=torch.int32)` with
+`dt = torch.tensor([0.01])` and `lifetime = 1.0`.
+Check whether the returned value is 990 (correct round) or 990 (truncation).
+Also inspect the dtype of the return value.
+
+**Fix direction:**  
+Keep the computation in float32 until after any rounding:
+```python
+survived = (charge.to(torch.float32) * torch.exp(-dt / lifetime))
+return torch.where(dt >= 0, survived.round().to(torch.int32), charge)
+```
+
+---
+
+## BUG-05 — `_ensure_tail_closer_to_anode` uses fragile in-place swap   {#tail-swap}
+
+**Severity:** nit (currently correct but fragile)  
+**Location:** `src/tred/graph.py:205`
+
+```python
+tail_new[swap_idx], head_new[swap_idx] = head_new[swap_idx].clone(), tail_new[swap_idx].clone()
+```
+
+**Problem:**  
+Python evaluates the right-hand side as a tuple before assigning; the
+`.clone()` calls prevent aliasing.  The code works correctly today.  However:
+1. The implementation clones *both* `tail` and `head` unconditionally at
+   `graph.py:188`, even when no swap is needed (e.g. `swap_idx` is empty).
+   This doubles the memory used for positions on every batch.
+2. The pattern is non-obvious and easy to break: if a future editor removes
+   either `.clone()`, the swap silently becomes wrong (both sides alias the
+   same modified tensor).
+
+**Fix direction:**  
+Use a temporary buffer:
+```python
+tmp = tail_new[swap_idx].clone()
+tail_new[swap_idx] = head_new[swap_idx]
+head_new[swap_idx] = tmp
+```
+Or avoid the unconditional clone by checking whether any swap is needed
+before allocating `tail_new` / `head_new`.
+
+---
+
+## BUG-06 — NaN silencing in diffusion masks real upstream errors   {#nan-mask}
+
+**Severity:** possible  
+**Location:** `src/tred/drift.py:77`
+
+```python
+sigma[torch.isnan(sigma)] = 0
+```
+
+**Problem:**  
+NaNs in `sigma` arise when `dt < 0` (a step drifts "backward") or when
+`sigma=None` and `dt=0` (zero-time diffusion).  Setting them silently to 0
+hides the underlying issue and causes downstream effects:
+- Zero sigma is handled with a special `spikes` path in `raster/depos.py:113`
+  (point-charge grid assignment) — meaning a step that should have some
+  spatial extent is treated as a point charge.
+- Steps with negative drift time (possibly from bad geometry or floating-point
+  rounding near the anode) are treated as zero-width, creating spurious
+  point-like depositions.
+
+**Fix direction:**  
+At minimum, log a warning when NaNs are found.  Better: clamp `dt` to ≥ 0
+before computing sigma, and separately track which steps have `dt < 0`
+(they should be dropped as unphysical).
+
+---
+
+## BUG-07 — `concatenate_waveforms` uses `index_put_` with `accumulate=False`   {#waveform-overwrite}
+
+**Severity:** possible  
+**Location:** `src/tred/plots/graph_effq.py:136`
+
+```python
+wf_out.index_put_((flat_batch, flat_time), flat_values, accumulate=False)
+```
+
+**Problem:**  
+If two current-block entries map to the same `(pixel, time_tick)` the second
+overwrites the first (no accumulation).  This should not happen if the sparse
+current blocks are properly non-overlapping by this point, but it is not
+guaranteed by any assertion.  Silent data corruption if the assumption is
+violated.
+
+**Fix direction:**  
+Either use `accumulate=True` (correct in all cases) or add an assertion that
+no `(flat_batch, flat_time)` pair is repeated.
+
+---
+
+## BUG-08 — `nd_readout` return path for empty hits is unreachable   {#readout-dead-code}
+
+**Severity:** nit  
+**Location:** `src/tred/readout.py:141`
+
+```python
+if len(olocs) == 0:
+    return torch.zeros((0, len(pixel_axes)+3), ...), torch.zeros((0,), ...)
+    raise NotImplementedError("Not sure how to handle empty hit collection")
+```
+
+**Problem:**  
+The `raise NotImplementedError` is dead code: the `return` statement on the
+preceding line means it is never reached.  The comment suggests the developer
+left it as a placeholder, but it gives a false impression that empty
+collections are unhandled.
+
+**Fix direction:**  
+Remove the dead `raise` line; the existing `return` is correct.
+
+---
+
+## BUG-09 — `readout.py` `start` initialisation ignores leftover charge   {#readout-leftover}
+
+**Severity:** possible  
+**Location:** `src/tred/readout.py:48–49`
+
+```python
+# FIXME: start should be initialized according to leftover
+start = torch.zeros(...)
+```
+
+**Problem:**  
+When events are processed in batches, charge that accumulates up to the end
+of the batch window but doesn't cross threshold ("leftover") is discarded.
+The `leftover` parameter exists in the function signature but raises
+`NotImplementedError` if not None.  This means near-threshold signals split
+across batch boundaries can be missed, which affects trigger efficiency.
+
+**Fix direction:**  
+Implement the leftover accumulator.  This requires tracking `Xacc[:,-1]` at
+the end of each batch and passing it as the initial value for the next.
+
+---
+
+## BUG-10 — `chunkify2` type-check on `stride` dtype is self-referential   {#chunkify2-typeguard}
+
+**Severity:** nit  
+**Location:** `src/tred/sparse.py:174–175`
+
+```python
+if stride.dtype != stride.dtype != offset_dtype:
+```
+
+**Problem:**  
+The condition is `stride.dtype != stride.dtype` which is always `False`
+(a value is always equal to itself), making the entire check a no-op.
+The intended check was probably `stride.dtype != offset_dtype`.
+
+**Fix direction:**
+```python
+if stride.dtype != offset_dtype:
+```

--- a/docs/examinations/03_gpu_efficiency.md
+++ b/docs/examinations/03_gpu_efficiency.md
@@ -1,0 +1,381 @@
+# TRED GPU Runtime Efficiency
+
+> Read-only examination.  No source files were modified.
+> Impact tags: **high** / **medium** / **low**.
+> Change tags: **quick-win** (few lines) / **structural** (design change).
+
+See [01_algorithms.md](01_algorithms.md) for algorithm context.
+
+---
+
+## Overview: where time goes
+
+The repo root `itpc_timing_summary.{csv,json}` and `pie_chart_*.png` show
+prior profiling.  The most expensive stages are typically (in rough order):
+1. Convolution (`convo`) — repeated FFT per lace pair per chunk.
+2. Raster (`raster`) — float64, per-step computation.
+3. ChunkSum charge/current — scattered sparse accumulation.
+
+The findings below address inefficiencies in each stage.
+
+---
+
+## EFF-01 — Float64 in entire step-raster module   {#fp64}
+
+**Impact:** high  
+**Change:** structural (precision study needed)  
+**Location:** `src/tred/raster/steps.py:11`
+
+```python
+float_dtype = torch.float64
+```
+
+All tensors allocated in `steps.py` are float64.  On consumer/mid-range
+CUDA GPUs (e.g. RTX 3090/4090, A100 40GB), fp64 throughput is
+**1/32× to 1/64×** the fp32 throughput.  This single line multiplies the
+effective compute time of the entire rasterisation stage by up to 64.
+
+The precision requirement comes from the analytical integrand
+`qline_diff3D_script` which involves differences of erfs and ratios of
+large/small numbers.  A study to determine whether fp32 + compensated
+summation is sufficient, or whether only the critical sub-expressions need
+fp64, would allow a mixed-precision strategy.
+
+**Immediate win:**  
+Change `float_dtype = torch.float32` and run validation tests to identify
+which sub-expressions lose accuracy.  Even partial fp32 (compute in fp32,
+accumulate in fp64) would help.
+
+---
+
+## EFF-02 — Response FFT recomputed on every forward call   {#fft-cache}
+
+**Impact:** high  
+**Change:** quick-win  
+**Location:** `src/tred/convo.py:385`
+
+```python
+meas_ = torch.fft.fftn(res_[None,...], dim=dims) * torch.fft.fftn(meas_, dim=dims)
+```
+
+Inside `interlaced_symm_v2`, the response lace `res_` is FFT'd on every call
+to `forward()`.  The response tensor is constant across all batches and
+events; its FFT should be computed once and cached.
+
+The function docstring and existing code have a `# fixme: allow for response
+to be pre-FFT'ed` comment (`graph.py:453`), confirming the intent.
+
+The response has shape `(90, 90, 6400)`.  Each lace extracted from it has
+shape roughly `(9, 9, 6400)`.  With `nimperpix/2 = 5` pairs per axis and
+two spatial axes, there are 25 lace pairs per forward call.  Caching all 25
+FFT'd laces (computed once at construction time) would eliminate ~25 FFT
+calls per batch.
+
+**Implementation sketch:**  
+Add a `_precompute_response_ffts(response, o_shape)` method to `LacedConvo`
+that runs `deinterlace_pairs` on the response and stores the FFT'd laces.
+Call it in `LacedConvo.__init__` or lazily on first forward call.
+
+---
+
+## EFF-03 — Python for-loop in `accumulate_nd_blocks_v1`   {#v1-loop}
+
+**Impact:** high  
+**Change:** quick-win (use `_v2` instead)  
+**Location:** `src/tred/sparse.py:308–311`
+
+```python
+for u, up in enumerate(unique_pairs):
+    mask = (idx_exp == up).all(dim=-1)
+    out[u] = Xb[mask].sum(dim=0)
+```
+
+`accumulate_nd_blocks_v1` iterates over every unique chunk location in a
+Python loop, launching one boolean mask + sum kernel pair per unique chunk.
+For a realistic event with thousands of unique chunks, this is thousands of
+sequential CUDA kernel launches, each with GPU→CPU sync for the boolean check.
+This is the worst possible pattern for GPU utilisation.
+
+`accumulate_nd_blocks_v2` (`sparse.py:315`) uses `scatter_add_` and
+`index_add_` — single parallel operations — and should be dramatically faster.
+
+**Recommendation:**  
+Default `ChunkSum` should not use `method='chunksum_inplace_v1'` for
+production.  Ensure `_v2` or the `chunkify + accumulate` path is used.
+
+---
+
+## EFF-04 — CUDA-CPU sync in `chunkify2` via `.tolist()`   {#chunkify2-sync}
+
+**Impact:** medium  
+**Change:** quick-win  
+**Location:** `src/tred/sparse.py:264–265`
+
+```python
+# FIXME: CUDA-CPU SYNC
+data = torch.zeros((tile_keys.size(0),) + tuple(cshape.tolist()), ...)
+```
+
+`cshape.tolist()` forces the CUDA device to synchronise with the CPU to
+transfer the shape integers.  Since `cshape` is the fixed chunk shape
+(set at construction time), it could be cached as a Python tuple once at
+init time and passed directly.
+
+**Fix:**
+```python
+# In __init__: self._chunk_shape_tuple = to_tuple(chunk_shape)
+data = torch.zeros((tile_keys.size(0),) + self._chunk_shape_tuple, ...)
+```
+This is already done in `ChunkSum.__init__` (`graph.py:327`):
+```python
+self._chunk_shape_tuple = to_tuple(chunk_shape)
+```
+The cached value just needs to be threaded through to `chunkify2`.
+
+---
+
+## EFF-05 — `steps.cpu()` in `interlaced_symm_v2` hot path   {#convo-cpu-sync}
+
+**Impact:** medium  
+**Change:** quick-win  
+**Location:** `src/tred/convo.py:352, 359`
+
+```python
+c_shape = dft_shape(torch.tensor(signal.data.shape[1:]).to(steps.device)//steps,
+                    torch.tensor(response.shape).to(steps.device)//steps)
+...
+nrm1 = to_tensor(response.shape, device='cpu') // steps.cpu() - 1
+```
+
+Two patterns force CPU↔GPU transfers on every call:
+- `torch.tensor(signal.data.shape[1:])` creates a CPU tensor from Python ints,
+  then `.to(steps.device)` moves it.  `signal.data.shape` is always a Python
+  tuple of ints; the division by `steps` can be done in Python arithmetic
+  without any tensor.
+- `steps.cpu()` copies `steps` from GPU to CPU just to do integer division.
+  Since `steps` is a constant (set at `LacedConvo` construction), it should
+  be stored as a Python tuple.
+
+**Fix direction:**  
+Precompute these shapes at construction time and store as Python tuples or
+CPU tensors.
+
+---
+
+## EFF-06 — `torch.cuda.empty_cache()` inside the batch loop   {#empty-cache}
+
+**Impact:** medium  
+**Change:** quick-win (remove)  
+**Location:** `src/tred/graph.py:382, 428`
+
+```python
+torch.cuda.empty_cache()
+```
+
+`empty_cache()` releases GPU memory back to the OS allocator.  It is
+expensive (causes CUDA context synchronisation and cache flush), and in a
+tight batch loop it prevents PyTorch's memory allocator from reusing
+recently-freed blocks.  It should only be called when genuinely OOM and
+needing to free memory for a new allocation.
+
+The surrounding code in `_chunksum` / `_chunksum2` is already behind a
+`nchunks > 1` guard, but `nchunks == 1` for most events, and the code after
+`return accumulate(chunkify(block, self.chunk_shape))` on `graph.py:360` is
+**unreachable dead code** (the `return` statement on that line exits the
+function before the loop is entered).
+
+**Immediate action:**  
+The entire body of `_chunksum` from line 362 onward is dead code.  Remove it.
+The `empty_cache` calls go with it.
+
+---
+
+## EFF-07 — `torch.zeros(...).to(dat.device)` allocates then copies   {#zeros-device}
+
+**Impact:** medium  
+**Change:** quick-win  
+**Location:** `src/tred/chunking.py:150`
+
+```python
+summed = torch.zeros((unique_locs.shape[0], *dat.shape[1:]), dtype=dat.dtype).to(dat.device)
+```
+
+`torch.zeros(...)` without a `device=` argument allocates on CPU, then
+`.to(dat.device)` copies to GPU.  For large chunks this creates a
+CPU-side allocation and a transfer that can be avoided:
+
+```python
+summed = torch.zeros((unique_locs.shape[0], *dat.shape[1:]),
+                     dtype=dat.dtype, device=dat.device)
+```
+
+Same pattern likely occurs elsewhere when `torch.zeros` / `torch.ones` are
+called without explicit `device=`.
+
+---
+
+## EFF-08 — Per-dimension Python loop in `raster/depos.py`   {#depos-loop}
+
+**Impact:** medium  
+**Change:** structural  
+**Location:** `src/tred/raster/depos.py:193–214`
+
+```python
+for dim in range(vdims):
+    ...
+    rel_grid_ind = torch.linspace(0, 2*dim_n_half, 2*dim_n_half+1).to(device=device)
+    ...
+```
+
+Two inefficiencies in one loop:
+1. `torch.linspace(...)` returns a CPU tensor; `.to(device=device)` copies it
+   to GPU inside the loop.  Use `device=device` in the `linspace` call.
+2. The loop is a Python-level serialisation over spatial dimensions (vdim=3).
+   While only 3 iterations, each iteration is a separate set of CUDA kernels
+   launched sequentially.  This is a small but avoidable overhead.
+
+The comment in the code acknowledges it: `"Suffer per-dimension serialization.
+We do it because linspace() is 1D only."`
+
+**Fix:**  
+Use `torch.meshgrid` to compute all dimension indices simultaneously, then
+broadcast the erf computation across all dimensions at once.
+
+---
+
+## EFF-09 — Repeated `contiguous()` allocations in response loading   {#contiguous}
+
+**Impact:** low  
+**Change:** quick-win  
+**Location:** `src/tred/response.py:142, 146`
+
+```python
+full_response = quadrant_copy(raw).contiguous()
+...
+return response.contiguous()
+```
+
+Two `.contiguous()` calls create two full copies of the response tensor.
+Only the final `contiguous()` is needed (if the view/reshape chain left a
+non-contiguous layout).  The intermediate one on `full_response` is consumed
+only by `view`, which requires contiguity, so it is necessary — but the chain
+could potentially be restructured to require only one copy.
+
+---
+
+## EFF-10 — Readout while-loop forces repeated GPU-CPU syncs   {#readout-loop}
+
+**Impact:** medium (event-rate dependent)  
+**Change:** structural  
+**Location:** `src/tred/readout.py:67, 102`
+
+```python
+while True:
+    ...
+    if not triggered.any():
+        break
+```
+
+`triggered.any()` is a GPU reduction that returns a Python bool, forcing a
+GPU→CPU sync on every iteration.  For a typical ND-LAr event with O(100–1000)
+pixel firings spread across the time window, the number of iterations is
+bounded by the maximum number of ADC triggers per pixel.  Even so, 10–50
+iterations × GPU sync per batch is a non-negligible overhead.
+
+**Structural alternative:**  
+Compute all possible crossings in one pass by finding all threshold-crossing
+times simultaneously with `torch.argmax` and working out the dead-time logic
+analytically, eliminating the while-loop.
+
+---
+
+## EFF-11 — `locs.detach().clone()` on every drift call   {#drift-clone}
+
+**Impact:** low  
+**Change:** quick-win  
+**Location:** `src/tred/drift.py:154`
+
+```python
+locs = locs.detach().clone()
+```
+
+This clones the full position tensor before modifying `locs[:,vaxis]`.
+Since `drift()` is called from `Drifter.forward()` which has already cloned
+`tail` in `_ensure_tail_closer_to_anode`, the clone here may be redundant.
+If the caller can guarantee no aliasing, `locs[:, vaxis] = target + ...`
+can be done on a view instead.
+
+---
+
+## EFF-12 — No `torch.compile` or CUDA graphs   {#compile}
+
+**Impact:** high (potential)  
+**Change:** structural (experimental)  
+
+None of the hot path modules use `torch.compile` (inductor backend).
+For the convolution and scatter-accumulation stages, `torch.compile` with
+the inductor backend may provide 2–5× speedup by fusing elementwise ops and
+eliminating intermediate tensor allocations.
+
+A first experiment would be wrapping `LacedConvo.forward` and
+`chunking.accumulate` with `torch.compile`.
+
+---
+
+## EFF-13 — No use of `torch.fft.rfft` (real FFT)   {#rfft}
+
+**Impact:** medium  
+**Change:** quick-win  
+**Location:** `src/tred/convo.py:385, 390`
+
+```python
+meas_ = torch.fft.fftn(res_[None,...], dim=dims) * torch.fft.fftn(meas_, dim=dims)
+...
+meas = torch.fft.ifftn(meas, dim=dims)
+```
+
+The signal and response are real-valued tensors (or at least have a
+real-valued interpretation before the complex packing trick).  Using
+`torch.fft.rfftn` / `torch.fft.irfftn` would halve the size of the FFT and
+roughly halve the FFT compute time (the last dimension of the spectrum is
+`N//2 + 1` instead of `N`).
+
+The complex packing trick (`sig_lace_complex = torch.complex(...)`) is used
+to encode two real signals in one complex FFT; care would be needed to adapt
+this to `rfft`, but the principle carries over.
+
+---
+
+## EFF-14 — `hdf_keys` in `loaders.py:58` uses undefined variable   {#hdf-typo}
+
+**Impact:** low (runtime error on bad code path)  
+**Location:** `src/tred/loaders.py:62`
+
+```python
+obj = h5py.File(fobj)  # 'fobj' is not defined; should be 'obj'
+```
+
+This branch (`if isinstance(obj, str)`) would raise a `NameError` if the
+function is called with a string path.  The function is likely called with an
+already-open `h5py.Group` in practice, so this path is never exercised.
+
+---
+
+## Summary table
+
+| ID | Stage | Impact | Change effort |
+|----|-------|--------|---------------|
+| EFF-01 | Raster (float64) | **high** | structural |
+| EFF-02 | Convo (FFT cache) | **high** | quick-win |
+| EFF-03 | Sparse v1 loop | **high** | quick-win |
+| EFF-04 | chunkify2 sync | medium | quick-win |
+| EFF-05 | convo cpu sync | medium | quick-win |
+| EFF-06 | empty_cache in loop | medium | quick-win |
+| EFF-07 | zeros device | medium | quick-win |
+| EFF-08 | depos dim loop | medium | structural |
+| EFF-09 | contiguous alloc | low | quick-win |
+| EFF-10 | readout loop sync | medium | structural |
+| EFF-11 | drift clone | low | quick-win |
+| EFF-12 | no torch.compile | high (potential) | structural |
+| EFF-13 | fftn → rfftn | medium | quick-win |
+| EFF-14 | hdf_keys typo | low | quick-win |

--- a/docs/examinations/04_memory.md
+++ b/docs/examinations/04_memory.md
@@ -1,0 +1,276 @@
+# TRED Memory Usage Analysis
+
+> Read-only examination.  No source files were modified.
+> See also [01_algorithms.md](01_algorithms.md) for tensor shape context.
+
+---
+
+## 1. Peak Memory Map
+
+The GPU memory high-water mark is reached during the **rasterisation** or
+**convolution** stage (confirmed by the `op_w_max_mem` tracking in
+`plots/graph_effq.py:70–77`).  The breakdown per stage is:
+
+### 1.1 Raster (steps) — charge boxes
+
+Shape per batch of `N_steps` steps with universal box size `(Sx, Sy, St)`:
+
+```
+charge_boxes: (N_steps, Sx, Sy, St)  dtype=float64
+```
+
+Typical values: `N_steps = 32768`, `Sx = Sy ≈ 5–30`, `St ≈ 5–50`.
+
+**Example:** 32768 steps × 20 × 20 × 20 voxels × 8 bytes (float64) = **2.1 GB**
+
+This is before any accumulation.  The charge boxes must coexist with the
+offset tensor `(N_steps, 3)` (int32, negligible) and intermediate tensors
+in `compute_qeff`.
+
+### 1.2 Envelope (chunkify)
+
+`chunkify` allocates a dense `envelope` tensor spanning the bounding box of
+all charge boxes:
+
+```
+envelope: (Ex, Ey, Et)  dtype=float64
+```
+
+where `Ex` = max(location[:,0]) − min(location[:,0]) + Sx (rounded up to
+chunk boundary), similarly for other dims.
+
+For a typical event with steps spread over 100 pixels × 100 pixels × 7200
+time ticks and a chunk shape of (40, 40, 32), the envelope could be
+`(160, 160, 7232)`.
+
+**Example:** 160 × 160 × 7232 × 8 bytes = **1.5 GB**
+
+The charge boxes AND the envelope coexist during `fill_envelope`.
+
+### 1.3 Response tensor
+
+```
+response: (90, 90, 6400)  dtype=float32
+```
+
+Size: 90 × 90 × 6400 × 4 bytes = **207 MB** (constant, lives for full run).
+
+### 1.4 Convolution intermediates
+
+`interlaced_symm_v2` allocates:
+- `sig_lace_complex`: (N_chunks, c_shape[0], c_shape[1], c_shape[2])
+  complex64 = 2 × float32.
+  With `c_shape ≈ (8, 8, 512×4) = (8, 8, 2048)`, and 50 chunks:
+  50 × 8 × 8 × 2048 × 8 bytes ≈ **52 MB** per lace pair.
+- `meas`: same shape — accumulator across lace pairs.
+- Both alive simultaneously during the lace loop → 2 × 52 MB = **104 MB**
+  per batch of 50 chunks.
+
+For larger chunk batches or larger `o_shape`, this scales linearly.
+
+---
+
+## 2. Memory Savings Opportunities
+
+### MEM-01 — Universal box shape inflates charge-box tensor   {#universal-box}
+
+**Savings potential:** high  
+**Location:** `src/tred/raster/depos.py:176`,
+`src/tred/raster/steps.py:112–124` (`reduce_to_universal`)
+
+Both raster paths compute the largest box needed by any step in the batch
+and pad **all** steps to that size.  For a batch containing a mix of MIP
+tracks (small sigma) and heavily-diffused electrons (large sigma), the
+worst-case box size dominates, wasting memory for most steps.
+
+**Example:**  
+If 99% of steps need a 5×5×5 box but 1% need a 25×25×25 box, all steps are
+allocated as 25×25×25.  Memory usage is 25× higher than it needs to be for
+the majority of steps.
+
+**Mitigation strategies:**
+
+a. **Bucket by box size**: sort steps by sigma, group into buckets with
+   similar box sizes, run each bucket separately with its own universal shape.
+   Trade: more Python-level loops per batch vs. memory saving.
+
+b. **Per-step ragged boxes with padded batching**: pad to the median + N sigma
+   (not the maximum) and clip unusually large steps.
+
+c. **Reduce `N_steps` per batch**: reducing `batch_scheme[0]` from 32768
+   reduces the universe of sigmas per batch, reducing the worst-case size.
+   Current default is 32768; for steps with very heterogeneous sigma,
+   smaller batches (e.g. 4096) may give lower peak memory with only modest
+   throughput loss.
+
+---
+
+### MEM-02 — float64 charge boxes double GPU memory   {#fp64-memory}
+
+**Savings potential:** high  
+**Location:** `src/tred/raster/steps.py:11`
+
+`float_dtype = torch.float64` means every charge box element uses 8 bytes
+instead of 4 bytes for float32.  For the example in §1.1, this is the
+difference between 2.1 GB and 1.05 GB for the charge box tensor, and
+between 1.5 GB and 0.75 GB for the envelope.
+
+Converting to float32 (or mixed precision) would approximately **halve** the
+memory of the rasterisation stage.  See also
+[03_gpu_efficiency.md §EFF-01](03_gpu_efficiency.md#fp64).
+
+---
+
+### MEM-03 — Envelope allocation in `chunkify`   {#envelope-alloc}
+
+**Savings potential:** medium  
+**Location:** `src/tred/sparse.py:160–167`
+
+`fill_envelope` allocates a dense tensor spanning the full bounding box of
+all charge boxes (`sparse.py:119`).  For events with many spatially-spread
+charge boxes, this envelope is much larger than the total data in the boxes.
+
+`chunkify2` (`sparse.py:207`) avoids the envelope entirely, using index
+arithmetic instead.  The trade-off is a CUDA-CPU sync (see EFF-04) and more
+complex index logic.
+
+An alternative is to process `chunkify` on sub-regions of the detector
+(streaming over spatial tiles), capping the envelope size.
+
+---
+
+### MEM-04 — `locs.detach().clone()` in `drift.py`   {#drift-clone}
+
+**Savings potential:** low  
+**Location:** `src/tred/drift.py:154`
+
+Clones the full `(N_steps, 3)` position tensor on every drift call.
+For 32768 steps, this is 32768 × 3 × 4 bytes = 384 KB — small but
+unnecessary if the caller guarantees no aliasing.
+
+Similarly `_ensure_tail_closer_to_anode` (`graph.py:188`) clones both
+`tail` and `head` before any check of whether a swap is needed:
+
+```python
+tail_new, head_new = tail.clone().detach(), head.clone().detach()
+```
+
+For 32768 steps × 3 dims × 4 bytes × 2 tensors = 768 KB wasted per batch
+when no swap is needed.
+
+---
+
+### MEM-05 — Convolution accumulator keeps complex tensor alive   {#convo-complex-alive}
+
+**Savings potential:** medium  
+**Location:** `src/tred/convo.py:383–392`
+
+Inside the lace loop:
+```python
+res_  = zero_pad(res_lace[0], o_shape)      # real, padded response lace
+meas_ = zero_pad(sig_lace_complex, o_shape) # complex, padded signal lace
+meas_ = torch.fft.fftn(res_[None,...], ...) * torch.fft.fftn(meas_, ...)
+if meas is None:
+    meas = meas_
+else:
+    meas += meas_                            # accumulates into meas
+```
+
+`meas_` (shape ~ (N_chunks, c1, c2, c3) complex64) is created fresh each
+iteration and added to `meas` (same shape complex64).  Both coexist during
+the `+=` operation.  After the loop, `meas` holds the full complex spectrum.
+
+After `ifftn`, only `meas.real` is needed.  But `meas.imag` (the flipped
+symmetric partner) persists until the function returns.  The final computation:
+
+```python
+meas.real = meas.real + torch.flip(meas.imag, dims=flipdims)
+return Block(data=meas.real, ...)
+```
+
+...creates a temporary for `torch.flip(meas.imag)` alongside the full complex
+`meas`.  Peak usage here is ~3× the real-valued output tensor.
+
+**Fix:** Materialise the result immediately and discard `meas`:
+```python
+result = meas.real + torch.flip(meas.imag, dims=flipdims)
+del meas
+return Block(data=result, location=super_location)
+```
+
+---
+
+### MEM-06 — Response tensor FFT not cached; recomputed each call   {#response-fft-mem}
+
+**Savings potential:** low (but related to EFF-02)  
+**Location:** `src/tred/convo.py:385`
+
+Pre-computing the response FFT (`rfft` preferred) and storing it would add
+~207 MB of GPU memory (for float32 response) but eliminate repeated FFT
+compute and temporary allocations.  If `rfft` is used, only 106 MB is needed.
+
+The trade-off is: cache 106 MB permanently vs. allocate/free ~52 MB × 25
+times per batch.  For a GPU with ≥ 24 GB, the persistent cache is clearly
+preferable.
+
+---
+
+### MEM-07 — `BlockSparseBlock.size()` triggers CPU sync   {#block-size-sync}
+
+**Savings potential:** low (correctness concern)  
+**Location:** `src/tred/blocking.py:52–56`
+
+```python
+def size(self):
+    '''
+    Return torch.Size like a tensor.size() does. This includes batched dimension.
+
+    Warning: potential CPU-CUDA synchronization per call.
+    '''
+    return Size([self.nbatches] + self.shape.tolist())
+```
+
+`self.shape.tolist()` on a GPU tensor forces a CPU sync.  `Block.shape` is
+an integer tensor set at construction time from `data.shape[1:]` — which is
+always a Python int tuple.  The tensor could be kept as a Python tuple
+throughout, avoiding the sync entirely.
+
+---
+
+## 3. Peak Memory Estimates for a Typical ND-LAr Batch
+
+Assuming: N_steps=32768, universal box 20×20×30, chunk_shape=(40,40,32),
+response (90,90,6400), N_chunks≈2000 after accumulation:
+
+| Tensor | Size | Dtype | GPU MB |
+|--------|------|-------|--------|
+| Charge boxes | 32768 × 20×20×30 | float64 | **1180** |
+| Charge-box offsets | 32768 × 3 | int32 | 0.4 |
+| Envelope (chunkify) | ~160×160×7232 | float64 | **1326** |
+| Signal Block (after ChunkSum) | 2000 × 40×40×32 | float32 | **390** |
+| Response tensor | 90×90×6400 | float32 | **207** |
+| Convo meas (complex) | 2000×8×8×2048 | complex64 | **2048** |
+| **Estimated peak** | | | **~5000 MB** |
+
+This comfortably exceeds 4 GB and approaches 8 GB.  The 24 GB target
+(from `README.org`) is met, but with significant headroom consumed by the
+float64 and the envelope.  Converting to float32 throughout and optimising
+the envelope (MEM-01, MEM-02, MEM-03) could bring peak below 3 GB.
+
+---
+
+## 4. Quick Wins for Memory Reduction
+
+Ordered by expected saving with minimal risk:
+
+1. **float32 in `raster/steps.py`** — halves raster stage memory (~1.2 GB).
+   Risk: precision — needs validation.
+2. **`del meas` after ifftn in `convo.py`** — frees the accumulator complex
+   tensor (~2 GB at peak) before returning real part.  No correctness risk.
+3. **Reduce batch size** (`batch_scheme[0]`) — immediate, configuration-only.
+   Halving from 32768 to 16384 steps reduces charge-box tensor by ~2× and
+   reduces the worst-case envelope.
+4. **Fix `torch.zeros(...).to(device)`** (`chunking.py:150`) — avoids a CPU
+   buffer allocation for the accumulate tensor.
+5. **Cache response FFT** (`convo.py`) — saves ~52 MB × 25 re-allocations per
+   batch at the cost of 106 MB persistent.

--- a/docs/examinations/99_open_questions.md
+++ b/docs/examinations/99_open_questions.md
@@ -1,0 +1,182 @@
+# TRED Open Questions
+
+> These items could not be resolved by static code reading alone.
+> They require either running the simulation, a benchmark, or a design decision.
+> Prioritised roughly by expected impact.
+
+---
+
+## Q1 — Does `fill_envelope` actually receive overlapping blocks in practice?
+
+**Relates to:** [BUG-01](02_bugs.md#fill-envelope)
+
+`fill_envelope` assigns (not accumulates) into the envelope.  Whether this
+is a bug depends on whether the *source block* can contain two batch elements
+that map to the same envelope voxel.
+
+- If `chunkify` is always called with a block whose charge boxes are
+  non-overlapping (i.e. no two steps produce charge at the same grid point),
+  then the overwrite is safe.
+- If charge boxes from nearby steps overlap (very common for dense ionisation
+  tracks), then values are silently lost.
+
+**To resolve:**  
+Add a temporary diagnostic: before the assignment in `fill_envelope`,
+check `len(inds) > len(torch.unique(inds))` and log if True.
+Run on a muon track or beam event.
+
+---
+
+## Q2 — Is the `meas.real = …` assignment in `convo.py:391` a no-op?
+
+**Relates to:** [BUG-02](02_bugs.md#convo-real-assign)
+
+Whether `Tensor.real = expr` modifies the complex tensor in-place or rebinds
+a Python name depends on PyTorch version and tensor type.  If it is a no-op,
+the symmetric lace contribution is dropped and currents are wrong.
+
+**To resolve:**  
+Run a known test case (e.g. the existing `tests/convo/` tests) and compare
+output of `interlaced_symm_v2` vs `interlaced_symm` (which has independent
+implementation).  The outputs should match to numerical precision.
+
+---
+
+## Q3 — What is the actual fp32 vs fp64 precision loss in `qline_diff3D`?
+
+**Relates to:** [EFF-01](03_gpu_efficiency.md#fp64), [MEM-02](04_memory.md#fp64-memory)
+
+The analytical integrand in `qline_diff3D_script` (`steps.py:216`) involves:
+- A ratio of a Gaussian and a line-length-dependent prefactor `Q/(4π Δ)`.
+- Differences of erf values that can be very small when the line is far from
+  the evaluation point.
+- Squared terms that can span many orders of magnitude.
+
+Whether float32 is sufficient for physically meaningful precision
+(e.g. 1% accuracy on total charge per pixel) is unknown without testing.
+
+**To resolve:**  
+Run `compute_qeff` in both fp32 and fp64 on a representative set of steps
+(including short steps, very oblique steps, and heavily-diffused steps).
+Compare the resulting charge box sums.  Define an acceptable error bound
+(e.g. total charge error < 0.1%).
+
+---
+
+## Q4 — How large is the worst-case box shape for realistic ND-LAr events?
+
+**Relates to:** [MEM-01](04_memory.md#universal-box)
+
+The charge-box tensor size scales as `N_steps × Sx × Sy × St`.  The
+worst-case `(Sx, Sy, St)` depends on the maximum sigma in a batch.
+
+**To resolve:**  
+Add logging of `universal_shape` in `compute_charge_box` (`steps.py:127`)
+for a few representative events (cosmic muon, beam neutrino, stopping proton).
+This will give the actual memory usage breakdown and show how much padding
+is wasted.
+
+---
+
+## Q5 — What fraction of `accumulate`'s 1e-3 filter is non-zero signal?
+
+**Relates to:** [BUG-03](02_bugs.md#accumulate-threshold)
+
+`chunking.accumulate` drops chunks where `max|val| ≤ 1e-3`.  This is
+designed to suppress empty chunks, but may also suppress valid near-threshold
+signal.
+
+**To resolve:**  
+Log the number of chunks before and after the filter for a few events.
+Check whether any dropped chunks have non-zero charge (before convolution)
+or non-negligible current (after convolution).
+
+---
+
+## Q6 — Is `accumulate_nd_blocks_v2` correct under all input configurations?
+
+**Relates to:** [EFF-03](03_gpu_efficiency.md#v1-loop)
+
+`_v2` uses a `scatter_add_` path that involves an intermediate `uq` (unique
+locations after partial reduction) and `index_add_` on `acc0 → acc`.  The
+two-stage reduction is needed when input block shapes are larger than
+`cshape`, but the correctness of the index arithmetic across the batch
+dimension reduction has not been formally verified.
+
+**To resolve:**  
+Run the existing tests in `tests/` with `method='chunksum_inplace_v2'` and
+compare results to the reference `chunksum` method on the same inputs,
+particularly for blocks where `mshape[0] > 1` (outer batching).
+
+---
+
+## Q7 — What is the actual timing breakdown for the current code on a GPU?
+
+**Relates to:** profiling, prioritisation
+
+The `itpc_timing_summary.{csv,json}` files contain prior timing data, but
+may be from an older code version.  Fresh profiling with `nvprof` or
+`torch.profiler` would give:
+- Per-stage timing (raster, chunksum, convo, readout).
+- Per-kernel breakdown within convo (FFT time vs. multiply vs. overhead).
+- Memory transfer cost (CPU→GPU for each batch).
+
+**To resolve:**  
+Run `tred fullsim` with `benchmark_each_stage=True` on a representative event
+and collect `itpc_timing_summary`.  Run `torch.profiler` on the convo stage
+specifically to measure FFT cost vs. overhead.
+
+---
+
+## Q8 — Is the `leftover` charge between batch boundaries significant?
+
+**Relates to:** [BUG-09](02_bugs.md#readout-leftover)
+
+Charge accumulated on the CSA but not yet triggering at the end of one batch
+(`twindow_max = 7200 ticks`) is currently discarded.  For a muon crossing
+multiple batch windows or a long-lifetime process, this could cause missed
+triggers or wrong charge assignment.
+
+**To resolve:**  
+Estimate what fraction of ND-LAr events span more than one batch window.
+If events are typically shorter than the 600 µs window, this is negligible.
+
+---
+
+## Q9 — Is the response tensor orientation consistent with the charge-grid orientation?
+
+**Relates to:** [01_algorithms.md §7](01_algorithms.md#7-interlaced-convolution)
+
+`ndlarsim` in `response.py` applies a `torch.flip(response, dims=(0,2))` and
+a specific reshape of the quadrant-copied tensor.  Whether this correctly
+maps impact position [0,0] to the lower-left corner of the pixel (as claimed
+in the docstring) needs verification against known physics: a single electron
+landing at the pixel centre should induce the most current on the collection
+pixel, not on a neighbour.
+
+**To resolve:**  
+Run a single-electron "depo" at pixel centre and check which pixel has the
+largest integrated current in the output.
+
+---
+
+## Q10 — Does `Raster._transform` correctly handle the `tdim<0` case?
+
+**Relates to:** `graph.py:240–282`
+
+`Raster.__init__` adjusts `_tdim` for negative input:
+```python
+self._tdim = tdim if tdim>=0 else len(self._pdims) + 1 + tdim
+```
+When `tdim=-1` and `pdims=(1,2)` (the default), this gives `_tdim = 2`.
+
+In `_transform`, axes are reordered:
+```python
+axes.insert(self._tdim, old_tdim)
+```
+The correctness of this reordering under non-default `(pdims, tdim)`
+combinations has not been systematically tested.
+
+**To resolve:**  
+Add parametrised unit tests in `tests/` covering at least `tdim=0`, `tdim=-1`,
+and `pdims=(0,1)` with known transformations.


### PR DESCRIPTION
## Summary

- Adds `docs/examinations/` with 6 read-only examination documents covering the TRED GPU simulation codebase:
  - `00_overview.md` — full pipeline diagram, file map, data types, device strategy
  - `01_algorithms.md` — stage-by-stage algorithm explanations (recombination, drift, raster, BSB accumulation, interlaced convolution, readout, IO)
  - `02_bugs.md` — 10 potential correctness issues with file:line citations, severity tags, and fix directions
  - `03_gpu_efficiency.md` — 14 GPU runtime efficiency findings (float64 usage, FFT caching, Python loops, host/device syncs, dead code)
  - `04_memory.md` — peak memory estimates per stage, 7 memory-saving opportunities with rough savings estimates
  - `99_open_questions.md` — 10 items requiring benchmarks or design decisions before acting

No source code was modified. All findings cite exact `file:line` locations for easy navigation.

## Test plan

- [ ] Review each document for accuracy against the current source
- [ ] Prioritise findings in `02_bugs.md` and `03_gpu_efficiency.md` for follow-up work
- [ ] Use `99_open_questions.md` as a checklist for benchmark runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)